### PR TITLE
WP06-01: entity tokenizer schema + spec + bundled fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: 
+      - main
+      - gj/*
     tags: [ "v*" ]
   pull_request:
     branches: [ main ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,34 @@ Dynamic topology notes:
 - Current guardrail: `MADDPG` in `entity+dynamic` raises fail-fast on runtime topology mutation.
   Use `RuleBasedPolicy` (or another dynamic-ready agent) for dynamic topology scenarios.
 
+## Tokenizer Fixture (Entity Interface)
+
+`configs/tokenizers/fixtures/entity_obs_sample.json` is the pinned
+simulator-schema snapshot used by `validate_config` and by the tokenizer
+unit tests. The 5 hard-fail rules run against this fixture, so a
+tokenizer JSON that omits or misclassifies a column fails at
+config-load time.
+
+**Regenerate whenever the simulator schema changes** (columns
+added/removed/renamed in any entity table, new asset type, adapter
+emission order changed):
+
+```bash
+python scripts/dump_entity_obs_sample.py \
+    --config configs/templates/dynamic/rule_based_entity_dynamic_assets_only_local.yaml \
+    --output configs/tokenizers/fixtures/entity_obs_sample.json
+```
+
+If the new fixture uncovers uncovered features, `pytest
+tests/test_entity_tokenizer_config_schema.py` fails with a rule-1
+(coverage) violation — update `configs/tokenizers/entity_default.json`
+to classify the new columns (SRO / NFC / CA / excluded), then re-run
+tests.
+
+Any entity-mode YAML config works for the dump; the script only reads
+`env.entity_specs` (feature names + row ids) and the initial payload's
+edge structure.
+
 ## Outputs
 
 After training completes, all artifacts are organized in a job-specific directory:

--- a/configs/tokenizers/entity_default.json
+++ b/configs/tokenizers/entity_default.json
@@ -1,0 +1,228 @@
+{
+  "type_embeddings": { "SRO": 0, "NFC": 1, "CA": 2 },
+
+  "excluded_features": {
+    "patterns": [
+      "^district__topology_version$",
+      "^electric_vehicle_charger_state$",
+      "^electric_vehicle_soc$",
+      "^electric_vehicle_required_soc_departure$",
+      "^electric_vehicle_departure_time$",
+      "^electric_vehicle_is_flexible$",
+      "^charging_total_service_power_kw$",
+      "^charging_phase_L[123]_power_kw$",
+      "^district__community_flexible_.*$",
+      "^district__hour_(sin|cos)$",
+      "^district__day_type_(sin|cos)$",
+      "^district__month_(sin|cos)$",
+      "^district__seconds_of_day_(sin|cos)$",
+      "^district__is_weekend$",
+      "^pv_surplus_(power_kw|energy_kwh_step)$",
+      "^building_(import|export)_headroom_kw$",
+      "^(import|export)_phase_headroom_kw$",
+      "^flexible_(charge|discharge)_(power_capacity_kw|energy_capacity_kwh_step)$",
+      "^flexible_energy_(to_full_kwh|available_kwh)$",
+      "^(hour|day_type|month|seconds_of_day)_(sin|cos)$",
+      "^is_weekend$"
+    ]
+  },
+
+  "nfc": {
+    "type_name": "building_nfc",
+    "entity_table": "building",
+    "expression": {
+      "op": "subtract",
+      "left":  { "feature": "non_shiftable_load" },
+      "right": { "feature": "solar_generation" }
+    }
+  },
+
+  "ca_types": {
+    "storage": {
+      "entity_table": "storage",
+      "action_field": "electrical_storage",
+      "input_dim_fallback": 19
+    },
+    "charger": {
+      "entity_table": "charger",
+      "action_field": "electric_vehicle_storage",
+      "input_dim_fallback": 33
+    }
+  },
+
+  "sro_types": {
+    "district_time": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^district__month$",
+        "^district__day_type$",
+        "^district__hour$",
+        "^district__minutes$",
+        "^district__seconds$"
+      ],
+      "input_dim_fallback": 5
+    },
+    "district_weather_current": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^district__outdoor_dry_bulb_temperature$",
+        "^district__outdoor_relative_humidity$",
+        "^district__diffuse_solar_irradiance$",
+        "^district__direct_solar_irradiance$"
+      ],
+      "input_dim_fallback": 4
+    },
+    "district_weather_forecast": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^district__outdoor_dry_bulb_temperature_predicted_\\d+$",
+        "^district__outdoor_relative_humidity_predicted_\\d+$",
+        "^district__diffuse_solar_irradiance_predicted_\\d+$",
+        "^district__direct_solar_irradiance_predicted_\\d+$"
+      ],
+      "input_dim_fallback": 12
+    },
+    "district_carbon": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [ "^district__carbon_intensity$" ],
+      "input_dim_fallback": 1
+    },
+    "district_pricing_current": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [ "^district__electricity_pricing$" ],
+      "input_dim_fallback": 1
+    },
+    "district_pricing_forecast": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [ "^district__electricity_pricing_predicted_\\d+$" ],
+      "input_dim_fallback": 3
+    },
+    "district_community_energy": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^district__community_(net|import|export|pv|bess|ev)_(power_kw|energy_kwh_step)$"
+      ],
+      "input_dim_fallback": 12
+    },
+    "district_community_headroom": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^district__community_(building|phase)(_export)?_headroom_kw$"
+      ],
+      "input_dim_fallback": 4
+    },
+    "district_community_history": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^district__community_net_prev_\\d+_(kwh_step|mean_kwh_step)$"
+      ],
+      "input_dim_fallback": 2
+    },
+    "district_meta": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [ "^district__active_(buildings|chargers|evs)_count$" ],
+      "input_dim_fallback": 3
+    },
+
+    "building_storage_state": {
+      "entity_table": "building",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^electrical_storage_soc$",
+        "^electrical_storage_soc_ratio$"
+      ],
+      "input_dim_fallback": 2
+    },
+    "building_charging_phase_onehot": {
+      "entity_table": "building",
+      "cardinality": "singleton",
+      "feature_patterns": [ "^charging_phase_one_hot_.+$" ],
+      "input_dim_fallback": 6
+    },
+    "building_charging_headroom": {
+      "entity_table": "building",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^charging_(building|phase_L\\d+)(_export)?_headroom_kw$"
+      ],
+      "input_dim_fallback": 8
+    },
+    "building_charging_violation": {
+      "entity_table": "building",
+      "cardinality": "singleton",
+      "feature_patterns": [ "^charging_constraint_violation_kwh$" ],
+      "input_dim_fallback": 1
+    },
+    "building_energy_current": {
+      "entity_table": "building",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^net_electricity_consumption$",
+        "^(net|import|export|load|pv|bess|ev_charging)_(power_kw|energy_kwh_step)$"
+      ],
+      "input_dim_fallback": 15
+    },
+    "building_energy_history": {
+      "entity_table": "building",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^(net|import|export)_energy_prev_\\d+_(kwh_step|mean_kwh_step)$"
+      ],
+      "input_dim_fallback": 4
+    },
+    "building_meta": {
+      "entity_table": "building",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^active_chargers_count$",
+        "^active_storages_count$",
+        "^active_pvs_count$",
+        "^active_deferrable_appliances_count$"
+      ],
+      "input_dim_fallback": 4
+    },
+
+    "pv": {
+      "entity_table": "pv",
+      "cardinality": "per_asset",
+      "adapter_prefix": "pv::",
+      "input_dim_fallback": 4
+    },
+    "ev_connected": {
+      "entity_table": "ev",
+      "cardinality": "per_asset",
+      "adapter_prefix": "charger::",
+      "adapter_label": "connected_ev",
+      "input_dim_fallback": 8
+    },
+    "ev_incoming": {
+      "entity_table": "ev",
+      "cardinality": "per_asset",
+      "adapter_prefix": "charger::",
+      "adapter_label": "incoming_ev",
+      "input_dim_fallback": 8
+    },
+    "deferrable_appliance": {
+      "entity_table": "deferrable_appliance",
+      "cardinality": "per_asset",
+      "adapter_prefix": "deferrable_appliance::",
+      "input_dim_fallback": 5
+    }
+  },
+
+  "validation": {
+    "unmatched_features": "fail",
+    "ambiguous_pattern_match": "fail",
+    "input_dim_mismatch": "fail"
+  }
+}

--- a/configs/tokenizers/fixtures/entity_obs_sample.json
+++ b/configs/tokenizers/fixtures/entity_obs_sample.json
@@ -1,0 +1,1038 @@
+{
+  "schema": "/home/tiago/dev/Simulator/data/datasets/citylearn_three_phase_dynamic_topology_demo/schema.json",
+  "time_step": 2200,
+  "episode": 0,
+  "topology_version": 7,
+  "tables": {
+    "district": {
+      "features": [
+        "month",
+        "day_type",
+        "hour",
+        "outdoor_dry_bulb_temperature",
+        "outdoor_dry_bulb_temperature_predicted_1",
+        "outdoor_dry_bulb_temperature_predicted_2",
+        "outdoor_dry_bulb_temperature_predicted_3",
+        "outdoor_relative_humidity",
+        "outdoor_relative_humidity_predicted_1",
+        "outdoor_relative_humidity_predicted_2",
+        "outdoor_relative_humidity_predicted_3",
+        "diffuse_solar_irradiance",
+        "diffuse_solar_irradiance_predicted_1",
+        "diffuse_solar_irradiance_predicted_2",
+        "diffuse_solar_irradiance_predicted_3",
+        "direct_solar_irradiance",
+        "direct_solar_irradiance_predicted_1",
+        "direct_solar_irradiance_predicted_2",
+        "direct_solar_irradiance_predicted_3",
+        "carbon_intensity",
+        "electricity_pricing",
+        "electricity_pricing_predicted_1",
+        "electricity_pricing_predicted_2",
+        "electricity_pricing_predicted_3",
+        "community_net_power_kw",
+        "community_net_energy_kwh_step",
+        "community_import_power_kw",
+        "community_import_energy_kwh_step",
+        "community_export_power_kw",
+        "community_export_energy_kwh_step",
+        "community_pv_power_kw",
+        "community_pv_energy_kwh_step",
+        "community_bess_power_kw",
+        "community_bess_energy_kwh_step",
+        "community_ev_power_kw",
+        "community_ev_energy_kwh_step",
+        "community_building_headroom_kw",
+        "community_building_export_headroom_kw",
+        "community_phase_headroom_kw",
+        "community_phase_export_headroom_kw",
+        "active_buildings_count",
+        "active_chargers_count",
+        "active_evs_count",
+        "topology_version",
+        "community_net_prev_1_kwh_step",
+        "community_net_prev_3_mean_kwh_step"
+      ],
+      "units": [
+        "index",
+        "index",
+        "index",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "kw",
+        "kwh_step",
+        "kw",
+        "kwh_step",
+        "kw",
+        "kwh_step",
+        "kw",
+        "kwh_step",
+        "kw",
+        "kwh_step",
+        "kw",
+        "kwh_step",
+        "kw",
+        "kw",
+        "kw",
+        "kw",
+        "count",
+        "count",
+        "count",
+        "scalar",
+        "kwh_step",
+        "kwh_step"
+      ],
+      "rows": [
+        {
+          "id": "district_0"
+        }
+      ]
+    },
+    "building": {
+      "features": [
+        "non_shiftable_load",
+        "solar_generation",
+        "electrical_storage_soc",
+        "net_electricity_consumption",
+        "charging_phase_one_hot_charger_15_1_L1",
+        "charging_phase_one_hot_charger_15_1_L2",
+        "charging_phase_one_hot_charger_15_1_L3",
+        "charging_phase_one_hot_charger_15_2_L1",
+        "charging_phase_one_hot_charger_15_2_L2",
+        "charging_phase_one_hot_charger_15_2_L3",
+        "charging_building_headroom_kw",
+        "charging_phase_L1_headroom_kw",
+        "charging_phase_L2_headroom_kw",
+        "charging_phase_L3_headroom_kw",
+        "charging_building_export_headroom_kw",
+        "charging_phase_L1_export_headroom_kw",
+        "charging_phase_L2_export_headroom_kw",
+        "charging_phase_L3_export_headroom_kw",
+        "charging_constraint_violation_kwh",
+        "net_power_kw",
+        "net_energy_kwh_step",
+        "import_power_kw",
+        "import_energy_kwh_step",
+        "export_power_kw",
+        "export_energy_kwh_step",
+        "load_power_kw",
+        "load_energy_kwh_step",
+        "pv_power_kw",
+        "pv_energy_kwh_step",
+        "bess_power_kw",
+        "bess_energy_kwh_step",
+        "ev_charging_power_kw",
+        "ev_charging_energy_kwh_step",
+        "electrical_storage_soc_ratio",
+        "net_energy_prev_1_kwh_step",
+        "net_energy_prev_3_mean_kwh_step",
+        "import_energy_prev_1_kwh_step",
+        "export_energy_prev_1_kwh_step"
+      ],
+      "units": [
+        "scalar",
+        "kwh",
+        "ratio",
+        "kwh",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "scalar",
+        "kw",
+        "kw",
+        "kw",
+        "kw",
+        "kw",
+        "kw",
+        "kw",
+        "kw",
+        "kwh",
+        "kw",
+        "kwh_step",
+        "kw",
+        "kwh_step",
+        "kw",
+        "kwh_step",
+        "kw",
+        "kwh_step",
+        "kw",
+        "kwh_step",
+        "kw",
+        "kwh_step",
+        "kw",
+        "kwh_step",
+        "ratio",
+        "kwh_step",
+        "kwh_step",
+        "kwh_step",
+        "kwh_step"
+      ],
+      "rows": [
+        {
+          "id": "Building_1"
+        },
+        {
+          "id": "Building_2"
+        },
+        {
+          "id": "Building_3"
+        },
+        {
+          "id": "Building_4"
+        },
+        {
+          "id": "Building_5"
+        },
+        {
+          "id": "Building_6"
+        },
+        {
+          "id": "Building_7"
+        },
+        {
+          "id": "Building_8"
+        },
+        {
+          "id": "Building_9"
+        },
+        {
+          "id": "Building_10"
+        },
+        {
+          "id": "Building_11"
+        },
+        {
+          "id": "Building_12"
+        },
+        {
+          "id": "Building_13"
+        },
+        {
+          "id": "Building_14"
+        },
+        {
+          "id": "Building_15"
+        },
+        {
+          "id": "Building_16"
+        },
+        {
+          "id": "Building_17"
+        },
+        {
+          "id": "Building_18"
+        }
+      ]
+    },
+    "charger": {
+      "features": [
+        "connected_state",
+        "incoming_state",
+        "connected_ev_soc",
+        "connected_ev_required_soc_departure",
+        "connected_ev_battery_capacity_kwh",
+        "connected_ev_departure_time_step",
+        "incoming_ev_estimated_soc_arrival",
+        "incoming_ev_estimated_arrival_time_step",
+        "last_charged_kwh",
+        "max_charging_power_kw",
+        "max_discharging_power_kw",
+        "commanded_power_kw",
+        "applied_power_kw",
+        "applied_energy_kwh_step",
+        "energy_to_required_soc_kwh",
+        "avg_power_to_departure_kw"
+      ],
+      "units": [
+        "scalar",
+        "scalar",
+        "ratio",
+        "scalar",
+        "kwh",
+        "time_step",
+        "scalar",
+        "time_step",
+        "kwh",
+        "kw",
+        "kw",
+        "kw",
+        "kw",
+        "kwh_step",
+        "kwh",
+        "scalar"
+      ],
+      "rows": [
+        {
+          "id": "Building_1/charger_1_1"
+        },
+        {
+          "id": "Building_2/charger_2_dyn_1"
+        },
+        {
+          "id": "Building_4/charger_4_1"
+        },
+        {
+          "id": "Building_7/charger_7_1"
+        },
+        {
+          "id": "Building_10/charger_10_1"
+        },
+        {
+          "id": "Building_12/charger_12_1"
+        },
+        {
+          "id": "Building_15/charger_15_1"
+        },
+        {
+          "id": "Building_15/charger_15_2"
+        },
+        {
+          "id": "Building_18/charger_18_1"
+        }
+      ]
+    },
+    "ev": {
+      "features": [
+        "soc",
+        "battery_capacity_kwh",
+        "depth_of_discharge_ratio",
+        "soc_ratio",
+        "soc_min_ratio",
+        "soc_max_ratio",
+        "energy_available_kwh",
+        "energy_to_full_kwh"
+      ],
+      "units": [
+        "scalar",
+        "kwh",
+        "ratio",
+        "ratio",
+        "ratio",
+        "ratio",
+        "kwh",
+        "kwh"
+      ],
+      "rows": [
+        {
+          "id": "Electric_Vehicle_2"
+        },
+        {
+          "id": "Electric_Vehicle_3"
+        },
+        {
+          "id": "Electric_Vehicle_4"
+        },
+        {
+          "id": "Electric_Vehicle_5"
+        },
+        {
+          "id": "Electric_Vehicle_6"
+        },
+        {
+          "id": "Electric_Vehicle_7"
+        },
+        {
+          "id": "Electric_Vehicle_8"
+        },
+        {
+          "id": "Electric_Vehicle_9"
+        }
+      ]
+    },
+    "storage": {
+      "features": [
+        "soc",
+        "capacity_kwh",
+        "nominal_power_kw",
+        "electricity_consumption_kwh",
+        "electrical_storage_soc_ratio",
+        "max_charge_power_kw",
+        "max_discharge_power_kw",
+        "energy_to_full_kwh",
+        "energy_available_kwh"
+      ],
+      "units": [
+        "scalar",
+        "kwh",
+        "kw",
+        "kwh",
+        "ratio",
+        "kw",
+        "kw",
+        "kwh",
+        "kwh"
+      ],
+      "rows": [
+        {
+          "id": "Building_1/electrical_storage"
+        },
+        {
+          "id": "Building_2/electrical_storage"
+        },
+        {
+          "id": "Building_3/electrical_storage"
+        },
+        {
+          "id": "Building_4/electrical_storage"
+        },
+        {
+          "id": "Building_5/electrical_storage"
+        },
+        {
+          "id": "Building_6/electrical_storage"
+        },
+        {
+          "id": "Building_7/electrical_storage"
+        },
+        {
+          "id": "Building_8/electrical_storage"
+        },
+        {
+          "id": "Building_9/electrical_storage"
+        },
+        {
+          "id": "Building_10/electrical_storage"
+        },
+        {
+          "id": "Building_11/electrical_storage"
+        },
+        {
+          "id": "Building_13/electrical_storage"
+        },
+        {
+          "id": "Building_14/electrical_storage"
+        },
+        {
+          "id": "Building_15/electrical_storage"
+        },
+        {
+          "id": "Building_16/electrical_storage"
+        },
+        {
+          "id": "Building_17/electrical_storage"
+        },
+        {
+          "id": "Building_18/electrical_storage"
+        }
+      ]
+    },
+    "pv": {
+      "features": [
+        "generation_power_kw",
+        "generation_energy_kwh_step",
+        "installed_power_kw"
+      ],
+      "units": [
+        "kw",
+        "kwh_step",
+        "kw"
+      ],
+      "rows": [
+        {
+          "id": "Building_1/pv"
+        },
+        {
+          "id": "Building_2/pv"
+        },
+        {
+          "id": "Building_3/pv"
+        },
+        {
+          "id": "Building_4/pv"
+        },
+        {
+          "id": "Building_5/pv"
+        },
+        {
+          "id": "Building_6/pv"
+        },
+        {
+          "id": "Building_7/pv"
+        },
+        {
+          "id": "Building_8/pv"
+        },
+        {
+          "id": "Building_9/pv"
+        },
+        {
+          "id": "Building_10/pv"
+        },
+        {
+          "id": "Building_12/pv"
+        },
+        {
+          "id": "Building_13/pv"
+        },
+        {
+          "id": "Building_14/pv"
+        },
+        {
+          "id": "Building_15/pv"
+        },
+        {
+          "id": "Building_16/pv"
+        },
+        {
+          "id": "Building_17/pv"
+        },
+        {
+          "id": "Building_18/pv"
+        }
+      ]
+    }
+  },
+  "edges": {
+    "district_to_building": {
+      "source_table": null,
+      "target_table": null,
+      "edges": [
+        {
+          "source_index": 0,
+          "target_index": 0,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 0,
+          "target_index": 1,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 0,
+          "target_index": 2,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 0,
+          "target_index": 3,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 0,
+          "target_index": 4,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 0,
+          "target_index": 5,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 0,
+          "target_index": 6,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 0,
+          "target_index": 7,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 0,
+          "target_index": 8,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 0,
+          "target_index": 9,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 0,
+          "target_index": 10,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 0,
+          "target_index": 11,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 0,
+          "target_index": 12,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 0,
+          "target_index": 13,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 0,
+          "target_index": 14,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 0,
+          "target_index": 15,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 0,
+          "target_index": 16,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 0,
+          "target_index": 17,
+          "source_id": null,
+          "target_id": null
+        }
+      ]
+    },
+    "building_to_charger": {
+      "source_table": null,
+      "target_table": null,
+      "edges": [
+        {
+          "source_index": 0,
+          "target_index": 0,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 1,
+          "target_index": 1,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 3,
+          "target_index": 2,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 6,
+          "target_index": 3,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 9,
+          "target_index": 4,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 11,
+          "target_index": 5,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 14,
+          "target_index": 6,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 14,
+          "target_index": 7,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 17,
+          "target_index": 8,
+          "source_id": null,
+          "target_id": null
+        }
+      ]
+    },
+    "building_to_storage": {
+      "source_table": null,
+      "target_table": null,
+      "edges": [
+        {
+          "source_index": 0,
+          "target_index": 0,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 1,
+          "target_index": 1,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 2,
+          "target_index": 2,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 3,
+          "target_index": 3,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 4,
+          "target_index": 4,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 5,
+          "target_index": 5,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 6,
+          "target_index": 6,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 7,
+          "target_index": 7,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 8,
+          "target_index": 8,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 9,
+          "target_index": 9,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 10,
+          "target_index": 10,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 12,
+          "target_index": 11,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 13,
+          "target_index": 12,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 14,
+          "target_index": 13,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 15,
+          "target_index": 14,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 16,
+          "target_index": 15,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 17,
+          "target_index": 16,
+          "source_id": null,
+          "target_id": null
+        }
+      ]
+    },
+    "building_to_pv": {
+      "source_table": null,
+      "target_table": null,
+      "edges": [
+        {
+          "source_index": 0,
+          "target_index": 0,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 1,
+          "target_index": 1,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 2,
+          "target_index": 2,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 3,
+          "target_index": 3,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 4,
+          "target_index": 4,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 5,
+          "target_index": 5,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 6,
+          "target_index": 6,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 7,
+          "target_index": 7,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 8,
+          "target_index": 8,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 9,
+          "target_index": 9,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 11,
+          "target_index": 10,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 12,
+          "target_index": 11,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 13,
+          "target_index": 12,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 14,
+          "target_index": 13,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 15,
+          "target_index": 14,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 16,
+          "target_index": 15,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 17,
+          "target_index": 16,
+          "source_id": null,
+          "target_id": null
+        }
+      ]
+    },
+    "charger_to_ev_connected": {
+      "source_table": null,
+      "target_table": null,
+      "edges": [
+        {
+          "source_index": -1,
+          "target_index": -1,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": -1,
+          "target_index": -1,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 2,
+          "target_index": 6,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 3,
+          "target_index": 0,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 4,
+          "target_index": 1,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 5,
+          "target_index": 2,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 6,
+          "target_index": 3,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": 7,
+          "target_index": 4,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": -1,
+          "target_index": -1,
+          "source_id": null,
+          "target_id": null
+        }
+      ]
+    },
+    "charger_to_ev_connected_mask": {
+      "source_table": null,
+      "target_table": null,
+      "edges": []
+    },
+    "charger_to_ev_incoming": {
+      "source_table": null,
+      "target_table": null,
+      "edges": [
+        {
+          "source_index": -1,
+          "target_index": -1,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": -1,
+          "target_index": -1,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": -1,
+          "target_index": -1,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": -1,
+          "target_index": -1,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": -1,
+          "target_index": -1,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": -1,
+          "target_index": -1,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": -1,
+          "target_index": -1,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": -1,
+          "target_index": -1,
+          "source_id": null,
+          "target_id": null
+        },
+        {
+          "source_index": -1,
+          "target_index": -1,
+          "source_id": null,
+          "target_id": null
+        }
+      ]
+    },
+    "charger_to_ev_incoming_mask": {
+      "source_table": null,
+      "target_table": null,
+      "edges": []
+    }
+  },
+  "meta": {
+    "time_step": 2200,
+    "endogenous_time_step": 2199,
+    "spec_version": "entity_v1",
+    "temporal_semantics": {
+      "exogenous": "t",
+      "endogenous": "t_minus_1_settled"
+    },
+    "topology_version": 7
+  }
+}

--- a/docs/specv2.md
+++ b/docs/specv2.md
@@ -1,0 +1,1783 @@
+## Universal Local Controller — Specification v2 (Entity Interface, Dynamic Topology)
+
+> Reference v1: `docs/spec.md` and `docs/implementation_summary.md`.
+> Sample observation payload: `datasets/tmp_entity_obs_full_step2200_named.json`.
+> Target dataset: `citylearn_three_phase_dynamic_assets_only_demo`.
+> Reusable v1 source code is **not** present on this branch. It lives on
+> branch `gj/plan-c` (pinned to commit
+> `3e9a6737d7306b04f3516738f86a98ea52106ef5`). Implementing agents must check
+> that branch out (or `git show gj/plan-c:<path>`) to read the v1 modules
+> referenced below as “reuse from `gj/plan-c`”.
+> **No legacy (`flat`) interface logic should be added.** Anything new must
+> use the `entity` interface and `topology_version`-based topology tracking
+> introduced in `softcpsrecsimulator 0.3.0`.
+
+---
+
+## 0. Conventions
+
+- File paths are repo-relative.
+- Line references are pinned to current `HEAD` of this branch unless prefixed
+  with `gj/plan-c:` (e.g. `gj/plan-c:algorithms/utils/transformer_backbone.py`).
+- The phrase “the wrapper” means `utils/wrapper_citylearn.py:Wrapper_CityLearn`.
+- The phrase “the adapter” means
+  `utils/entity_adapter.py:EntityContractAdapter`.
+
+### 0.1 Token-family vocabulary
+
+v2 has **three** token families (down from four in earlier drafts — CTX
+has been collapsed into SRO):
+
+| Family | Cardinality per building | Has action output? | Examples |
+|---|---|---|---|
+| **CA** (Controllable Asset) | variable (one per asset) | Yes — exactly one scalar in `[-1, 1]` | `storage`, `charger` |
+| **NFC** (Non-Flexible Context) | exactly **one** per building | No | the scalar `non_shiftable_load - solar_generation` |
+| **SRO** (Shared Read-Only) | variable, multiple **types** per building | No | `district_pricing_current`, `district_weather_forecast`, `building_storage_state`, `pv`, `ev_connected`, … |
+
+The type embedding table has **3** entries: `SRO=0`, `NFC=1`, `CA=2`.
+
+“CTX” no longer appears anywhere in the design. Per-asset read-only
+streams that earlier drafts called CTX (`pv`, `ev_connected`,
+`ev_incoming`) are now SRO **types** with `cardinality: per_asset` (see
+§7.3). Per-feature-group district splits (`district_pricing_current`,
+`district_weather_forecast`, …) are SRO types with
+`cardinality: singleton`. The Transformer treats them all the same way
+at attention time; the per-type `Linear` projection is what gives them
+distinct embedding subspaces.
+
+### 0.2 Authoritative feature names
+
+The regex catalogs in §13.1 are derived from
+`datasets/tmp_entity_obs_full_step2200_named.json` (district 46
+features, building 38, charger 16, ev 8, storage 9, pv 3). Any new
+dataset version that introduces feature names not matched by an
+existing pattern must hard-fail at config validation time (see §13.4
+rule 1). The recommended fix is documented in the error message.
+
+---
+
+## 1. Objective & Core Principles
+
+### Objective
+
+Build a **Universal Local Controller (ULC)** that controls per-building energy
+assets using a Transformer-based architecture in which every asset (and every
+shared context source) is a token. The same trained model must handle, at
+runtime and without retraining:
+
+- Buildings with or without batteries / PV.
+- Variable numbers of EV chargers per building.
+- Mid-episode topology changes (assets entering / leaving) on the
+  `softcpsrecsimulator 0.3.0` entity interface.
+- There are **CA tokens** (controllable assets, one action output per
+  token), **SRO tokens** (shared / read-only context — variable count,
+  multiple types per building), and exactly **one NFC token per
+  building** (the scalar uncontrollable net load `non_shiftable_load -
+  solar_generation`).
+The agent produces one action per CA token, so the CA order must be consistent between observation and action sides. SRO and NFC tokens have **no action outputs** but feed into shared self-attention so they shape every CA action.
+
+The end goal is identical to v1. What changes in v2 is **how data flows in
+and out of the agent**: the simulator now exposes a structured `entity`
+contract with explicit `meta.topology_version`, so we no longer need
+sentinel marker values to recover token boundaries, and we no longer use
+asset/feature counting to detect topology changes.
+
+### Core Principles
+
+1. **Structure over sentinels.** Token boundaries are resolved from the
+   per-feature *origin metadata* the wrapper already produces (e.g.
+   `charger::Building_1/charger_1_1::connected_state`). No sentinel values
+   are injected into the observation tensor.
+2. **Topology-version-driven adaptation.** Topology changes are detected
+   exclusively via `meta.topology_version` increments. On change, the
+   wrapper rebuilds the per-building observation layout, the agent rebuilds
+   its tokenizer’s segment table, and the rollout buffer is flushed.
+3. **Wrapper owns the entity contract.** The agent receives a per-building
+   `np.ndarray` and returns a per-building `List[float]`. The wrapper
+   translates between the simulator’s entity payload and these flat vectors
+   in both directions via `EntityContractAdapter`.
+4. **Per-building agent.** Same architecture as v1 — independent
+   tokenizer / backbone / actor / critic / rollout buffer per building.
+5. **Reusable v1 components.** TransformerBackbone, ActorHead, CriticHead,
+   RolloutBuffer and the PPO loss are imported verbatim from `gj/plan-c`.
+   The marker-based ObservationEnricher and marker-scanning Tokenizer are
+   replaced by entity-aware modules.
+6. **Portability.** The new layout-builder module is pure-Python (stdlib +
+   typing only) so the production inference repo can reuse it without
+   pulling Torch.
+
+---
+
+## 2. Repo Delta from `gj/plan-c`
+
+### 2.1 What this checkout already has (entity side)
+
+| Path | Purpose | Lines |
+|---|---|---|
+| `utils/wrapper_citylearn.py` | Entity-mode detection, topology tracking, metadata attach, action conversion delegation | `:147-175`, `:309-365`, `:733-740` |
+| `utils/entity_adapter.py` | Per-building observation flattening (`to_agent_observations`) and flat→entity action conversion (`to_entity_actions`) | `:145-347`, `:486-552` |
+| `algorithms/agents/base_agent.py` | The exact agent contract this work must satisfy | `:16-84` |
+| `utils/config_schema.py` | Pydantic models, including the existing `topology_mode='dynamic'` ⇒ `interface='entity'` validator and the MADDPG-vs-`entity+dynamic` guardrail | `:117-118`, `:157-158`, `:344-356` |
+| `configs/templates/rule_based_entity_dynamic_assets_only_local.yaml` | Reference template shape we must mirror | full file |
+
+### 2.2 What is on `gj/plan-c` and **must be brought across or recreated**
+
+These files do **not** exist on this branch. The implementing agent must
+either copy them (preferred when reuse is verbatim) or rewrite them.
+
+| Path on `gj/plan-c` | Reuse policy in v2 |
+|---|---|
+| `algorithms/utils/transformer_backbone.py` | **Copy verbatim**, then update for v2 token families: 3-entry type embedding (`SRO=0, NFC=1, CA=2`) and `forward(sros, nfc, cas)` signature. |
+| `algorithms/utils/ppo_components.py` (Actor, Critic, RolloutBuffer, `compute_ppo_loss`) | **Copy verbatim.** No API change. |
+| `algorithms/agents/transformer_ppo/update_helper.py` | **Copy verbatim.** |
+| `algorithms/agents/transformer_ppo/export_helper.py` | Copy and adapt: input shape now derived from `BuildingTokenLayout`. |
+| `algorithms/agents/transformer_ppo/state_helper.py` | Copy, then **drop the marker registry**; add a `BuildingTokenLayout` field per building. |
+| `algorithms/agents/transformer_ppo_agent.py` | Copy, then surgically replace the enricher/marker-tokenizer wiring with the new entity layout/tokenizer. |
+| `algorithms/registry.py` change | Re-apply the `"AgentTransformerPPO"` registration. |
+
+### 2.3 Files created **net-new** in v2
+
+| Path | Purpose |
+|---|---|
+| `algorithms/utils/entity_token_layout.py` | Pure-Python `EntityTokenLayoutBuilder`, `BuildingTokenLayout`, `TokenSegment`. Replaces the v1 `ObservationEnricher`. |
+| `algorithms/utils/entity_observation_tokenizer.py` | Torch `EntityObservationTokenizer`. Replaces the v1 marker-scanning tokenizer. |
+| `utils/wrapper_transformer/__init__.py` + `transformer_observation_coordinator.py` | New coordinator hooks the layout builder into the wrapper’s entity lifecycle. |
+| `configs/tokenizers/entity_default.json` | New tokenizer config (entity-type based, no marker fields). |
+| `configs/templates/transformer_ppo_entity_dynamic.yaml` | New algorithm template; full repo-valid shape (see §13.2). |
+| Tests under `tests/` (see §16). | |
+
+### 2.4 Files modified
+
+| Path | Modification |
+|---|---|
+| `utils/wrapper_citylearn.py` | Add a `TransformerObservationCoordinator` hook (idempotent for non-Transformer agents). Generalise the `MADDPG`-specific dynamic guardrail (see §12.4). |
+| `utils/config_schema.py` | Add `EntityTokenizerConfig`, `TransformerConfig`, `TransformerPPOHyperparameters`, `TransformerPPOAlgorithmConfig`. Generalise the dynamic-topology guardrail to use a `supports_dynamic_topology` allow-list (keeping MADDPG’s rejection unchanged). Add JSON-validation for the file pointed to by `algorithm.tokenizer_config_path` (see §13.4). |
+| `algorithms/registry.py` | Register `"AgentTransformerPPO"`. |
+
+---
+
+## 3. Entity Interface Data Format
+
+Sample: `datasets/tmp_entity_obs_full_step2200_named.json` (step 2200,
+`topology_version = 7`). The payload has three top-level fields: `tables`,
+`edges`, `meta`.
+
+### 3.1 `tables`
+
+Each table has `features` (column names), `units`, and `rows` (list of dicts
+with `id` + values). Tables observed in the demo dataset:
+
+| Table | Cardinality | Feature count (sample) | Role | Tokenization |
+|---|---|---|---|---|
+| `district` | 1 | 46 | Community-wide context: weather, prices, carbon, time, community-level KPIs, `topology_version`, `active_*_count` | **Multiple SRO tokens** (one per semantic group: time, weather current, weather forecast, carbon, pricing current, pricing forecast, community energy, community headroom, community history, meta) |
+| `building` | N | 38 | Per-building load / generation / storage SOC, headroom, energy book-keeping | **NFC token** (`non_shiftable_load - solar_generation` scalar) + **multiple SRO tokens** (storage state, charging phase one-hots, charging headroom, charging violation, energy current, energy history, building meta) |
+| `charger` | M | 16 | Per-charger state and EV-related context | **CA token** per charger |
+| `storage` | up to N | 9 | Per-building battery state | **CA token** per storage |
+| `pv` | up to N | 3 | Per-building PV state | **SRO token** per PV (per-asset cardinality) |
+| `ev` | K | 8 | EV state (SOC, capacity, ratios) | **SRO token** per EV (split into `ev_connected` / `ev_incoming` per parent charger) |
+
+Counts above match `datasets/tmp_entity_obs_full_step2200_named.json` and
+must be reverified during implementation against the active dataset’s
+`entity_specs` (see §8.4).
+
+### 3.2 `edges`
+
+Topology graph; the wrapper consumes these to slice the global tables down
+to per-building views.
+
+| Edge name | Meaning |
+|---|---|
+| `district_to_building` | Always 1→all. |
+| `building_to_charger` | Which chargers belong to a building. |
+| `building_to_storage` | Which storage units belong to a building. |
+| `building_to_pv` | Which PVs belong to a building. |
+| `charger_to_ev_connected` (+ `_mask`) | Currently-connected EV per charger; `-1` = none. |
+| `charger_to_ev_incoming` (+ `_mask`) | Reserved/incoming EV per charger; `-1` = none. |
+
+### 3.3 `meta`
+
+```json
+{
+  "time_step": 2200,
+  "endogenous_time_step": 2199,
+  "spec_version": "entity_v1",
+  "temporal_semantics": {"exogenous": "t", "endogenous": "t_minus_1_settled"},
+  "topology_version": 7
+}
+```
+
+`topology_version` is the **single source of truth** for layout invalidation.
+
+### 3.4 Action contract (current ground truth)
+
+The adapter (`utils/entity_adapter.py:486-552`) returns:
+
+```python
+{
+  "tables": {
+    "building": np.zeros((n_buildings, len(building_action_features)), dtype=np.float32),
+    "charger": np.zeros((n_chargers, len(charger_action_features)), dtype=np.float32),
+  }
+}
+```
+
+It does **not** emit a `"map"` field today. The schema in `softcpsrecsimulator
+0.3.0`’s example uses `tables + map`, but the env accepts the tables-only
+form already in production via `to_entity_actions`. **v2 keeps the
+tables-only payload and does not add a `map` field**; if a future version
+of the simulator requires it, the change is local to
+`EntityContractAdapter.to_entity_actions` and invisible to the agent.
+
+Source of truth for shape and ordering:
+
+- `env.entity_specs["actions"]["building"]["features"]` — building action feature
+  names (e.g. `electrical_storage`).
+- `env.entity_specs["actions"]["charger"]["features"]` — charger action feature
+  names (e.g. `electric_vehicle_storage`).
+- `env.entity_specs["actions"]["building"]["ids"]` and `["charger"]["ids"]` —
+  row order of the action tables.
+- `env.action_space["tables"]["building"|"charger"].shape` — current shapes
+  (change on topology mutation).
+
+---
+
+## 4. End-to-End Data Flow
+
+```
+                                                      step()
+                                                         │
+   ┌──────────────────────────────────────────────────────┴──────────────────────┐
+   │                       softcpsrecsimulator 0.3.0 (CityLearnEnv)              │
+   │  interface=entity                                                           │
+   │  topology_mode=dynamic                                                      │
+   └────────────────────────────────┬────────────────────────────────────────────┘
+                                    │ entity payload {tables, edges, meta}
+                                    ▼
+ ┌────────────────────────────────────────────────────────────────────────────────┐
+ │ Wrapper_CityLearn (utils/wrapper_citylearn.py)                                 │
+ │                                                                                │
+ │ 1. EntityContractAdapter.to_agent_observations(payload)                        │
+ │    → for each building: a flat np.ndarray + observation_names + space          │
+ │    → updates self._entity_topology_version                                     │
+ │                                                                                │
+ │ 2. Topology change?  (self._entity_topology_version != previous_version)       │
+ │    YES (and previous_version is not None)                                      │
+ │      → self.encoders = self.set_encoders()      (placeholder NoNormalization)  │
+ │      → wrapper._attach_model_environment_metadata()   (re-emits entity_specs   │
+ │            + new observation_names + new action_names BEFORE layout rebuild)   │
+ │      → coordinator.handle_topology_change(self) → for each building:           │
+ │            agent.on_topology_change(b)                                         │
+ │              ├─ flush rollout_buffer[b] (PPO update on previous layout)        │
+ │              ├─ layouts[b] = layout_builder.build(                             │
+ │              │      building_id[b], observation_names[b], action_names[b])    │
+ │              ├─ re-pre-register tokenizer index buffers                        │
+ │              └─ assert layouts[b].ca_action_names == action_names[b]           │
+ │                                                                                │
+ │ 3. agent.predict(encoded_obs, deterministic) → List[List[float]]               │
+ │    where encoded_obs[b] = adapter.normalize_observation(b, raw_obs[b], ...)    │
+ │    (see utils/wrapper_citylearn.py:964-988 — current behaviour)                │
+ │                                                                                │
+ │ 4. EntityContractAdapter.to_entity_actions(actions, action_names)              │
+ │    → {"tables": {"building": np.ndarray, "charger": np.ndarray}}               │
+ └────────────────────────────────┬───────────────────────────────────────────────┘
+                                  │ flat vectors per building
+                                  ▼
+ ┌────────────────────────────────────────────────────────────────────────────────┐
+ │ AgentTransformerPPO.predict() — per building b                                 │
+ │                                                                                │
+ │  EntityObservationTokenizer.forward(encoded_b, layout_b)                       │
+ │     ├─ Slice encoded vector by `layout_b.segments` via torch.index_select      │
+ │     ├─ NFC segment: gather 2 source features, apply NfcExpression              │
+ │     │     (subtract) → scalar → project via projections["building_nfc"]        │
+ │     ├─ All other segments: per-type Linear projection → d_model                │
+ │     └─ Returns TokenizedObservation:                                           │
+ │           {sro_tokens: N_sro, nfc_token: 1, ca_tokens: N_ca}                   │
+ │                                                                                │
+ │  TransformerBackbone.forward(sros, nfc, cas)                                   │
+ │     ├─ Concat tokens [sros…, nfc, cas…], add type embedding                    │
+ │     │     (SRO=0, NFC=1, CA=2 — 3 entries)                                     │
+ │     ├─ TransformerEncoder (Pre-LN, GELU)                                       │
+ │     └─ Returns all_embeddings + ca_embeddings + pooled                         │
+ │                                                                                │
+ │  ActorHead(ca_embeddings, ca_types) → actions [N_ca_b, 1] in [-1, 1]           │
+ │  CriticHead(pooled) → V(s) scalar                                              │
+ │                                                                                │
+ │  if training: RolloutBuffer.add(...)                                           │
+ │  on update_step: PPO update (GAE, clipped surrogate, K epochs)                 │
+ └────────────────────────────────────────────────────────────────────────────────┘
+```
+
+> Reminder: although the entity payload is community-wide, the
+> `EntityContractAdapter` already produces **one flat vector per building**
+> (`utils/entity_adapter.py:145`). The agent therefore stays per-building.
+
+---
+
+## 5. Definitive Observation Contract
+
+This section is the authoritative reference for the layout builder and
+tokenizer tests. It mirrors the emission order of
+`EntityContractAdapter.to_agent_observations` (`utils/entity_adapter.py:213-329`).
+
+### 5.1 Per-building emission order
+
+For each building `b` (in district-to-building edge order), names are
+appended to `observation_names[b]` in this exact order:
+
+1. **District block** — one feature per `district` table column, prefixed
+   `district__<feature>` (`utils/entity_adapter.py:215`).
+2. **Building block** — one feature per `building` table column,
+   **unprefixed** (`utils/entity_adapter.py:223`). Example names from the
+   sample payload: `non_shiftable_load`, `solar_generation`,
+   `electrical_storage_soc`, `net_electricity_consumption`,
+   `charging_phase_one_hot_charger_15_1_L1`, …
+3. **Per-storage blocks** — for each storage row attached to this building,
+   prefixed `storage::<storage_id>::<feature>`
+   (`utils/entity_adapter.py:239`).
+4. **Per-PV blocks** — for each PV row attached to this building, prefixed
+   `pv::<pv_id>::<feature>` (`utils/entity_adapter.py:250`).
+5. **Per-charger blocks**, in this order per charger
+   (`utils/entity_adapter.py:258-296`):
+   1. Charger features prefixed `charger::<charger_id>::<feature>`.
+   2. Connected-EV context features prefixed
+      `charger::<charger_id>::connected_ev::<feature>`. **The label is
+      exactly `connected_ev`** (`utils/entity_adapter.py:291`).
+   3. Incoming-EV context features prefixed
+      `charger::<charger_id>::incoming_ev::<feature>`. **The label is
+      exactly `incoming_ev`** (`utils/entity_adapter.py:294`).
+6. **Active-counters block** — three unprefixed features:
+   `active_chargers_count`, `active_storages_count`, `active_pvs_count`
+   (`utils/entity_adapter.py:298-300`).
+7. **Legacy-charger-aliases block** — zero or more unprefixed features whose
+   names come from `EntityContractAdapter._LEGACY_CHARGER_ALIASES`
+   (`utils/entity_adapter.py:302-329`). These are RBC-compatibility aliases
+   sourced from the building’s first connected charger. **In v2 these are
+   excluded from the token catalog** (see §5.4 / §13.1
+   `excluded_features`); they remain in `observation_names` for adapter
+   compatibility but are not bound to any token.
+
+### 5.2 Token-family classification
+
+Classification is **regex-driven and config-driven** (see §13.1 for the
+full tokenizer JSON). The high-level rule per feature is:
+
+| Feature pattern | Family | Type name | Instance id | Notes |
+|---|---|---|---|---|
+| Matches an SRO type’s `feature_patterns` (district / building scope) | `sro` | the SRO type name | building id (since SRO patterns are evaluated per building) | Singleton SRO types yield one token per building. |
+| Per-asset SRO `entity_table` prefix in name (e.g. `pv::<id>::…`, `charger::<id>::connected_ev::…`, `charger::<id>::incoming_ev::…`) | `sro` | `pv` / `ev_connected` / `ev_incoming` | `<id>` | Variable count per building. |
+| `storage::<id>::<feature>` | `ca` | `storage` | `<id>` | Action `electrical_storage`. |
+| `charger::<id>::<feature>` (no `connected_ev`/`incoming_ev` segment) | `ca` | `charger` | `<id>` | Action `electric_vehicle_storage`. |
+| Matches `nfc.expression` source features (`non_shiftable_load`, `solar_generation`) | `nfc` | `building` | `<building_id>` | Two source features collapse into **one** scalar token via the configured expression. |
+| Matches `excluded_features` patterns | (excluded) | — | — | Removed before classification (see §5.4). |
+| Anything else | (error) | — | — | Hard-fail at validation (§13.4 rule 1). |
+
+Notes:
+
+- **One feature → one match**: tokenizer JSON validation rule 2
+  (uniqueness, §13.4) guarantees no feature is matched by patterns from
+  more than one SRO type.
+- **NFC is a scalar**: the NFC token has dim 1 — the value of
+  `non_shiftable_load - solar_generation`. The two source features are
+  consumed and **do not** appear in any SRO group.
+- **SRO type input dim** is the count of features that match its
+  `feature_patterns` (for table-scoped SRO types) or
+  `len(entity_specs.tables[<entity_table>].features)` (for per-asset
+  SRO types). This count is fixed per topology and used to size the
+  per-type `Linear` projection (§8).
+- **Non-contiguous indices**: an SRO type’s feature positions in
+  `observation_names` may be non-contiguous (e.g.
+  `district_weather_forecast` mixes `outdoor_dry_bulb_temperature_predicted_*`
+  and `direct_solar_irradiance_predicted_*`). The layout records the
+  full index list per group; the tokenizer slices via
+  `torch.index_select` (§8.3).
+
+### 5.3 Why no marker injection
+
+v1 used numeric markers because the legacy `flat` interface emitted a single
+unstructured vector. With `interface=entity`, the wrapper already emits
+deterministic per-feature names (see §5.1). We classify them once per
+topology via the regex catalog (§13.1) and slice the encoded tensor at
+fixed integer indices every step.
+
+### 5.4 Excluded features
+
+The tokenizer config carries an `excluded_features` list of patterns
+(see §13.1). Features matching any pattern are removed *before*
+classification. Use cases:
+
+- **`topology_version`** (in the district table) — already conveyed via
+  `meta.topology_version`; redundant as an observation feature.
+- **Legacy charger aliases** (`electric_vehicle_charger_state`,
+  `electric_vehicle_soc`, `electric_vehicle_required_soc_departure`,
+  `electric_vehicle_departure_time`, `electric_vehicle_is_flexible`)
+  emitted by `EntityContractAdapter._LEGACY_CHARGER_ALIASES`
+  (`utils/entity_adapter.py:302-321`) — kept for RBC compatibility but
+  redundant with the per-charger CA tokens for the Transformer.
+
+This is the primary "feature engineering" knob: to remove a feature
+from the agent’s view, add a pattern to `excluded_features`. Removed
+features are still emitted by the adapter (we do not modify the
+adapter); they are simply not bound to any token.
+
+The exclusion list is part of the tokenizer config so that exclusions
+travel with the model (training and inference must agree).
+
+---
+
+## 6. Encoding Story (entity mode)
+
+This is intentionally minimal in the current code base.
+
+### 6.1 Current behaviour
+
+- `Wrapper_CityLearn.set_encoders()` returns a list of `NoNormalization()`
+  placeholders when `interface=entity`
+  (`utils/wrapper_citylearn.py:1100-1108`).
+- `Wrapper_CityLearn.get_encoded_observations(index, observations)` ignores
+  those placeholders and instead delegates to
+  `EntityContractAdapter.normalize_observation(...)`
+  (`utils/wrapper_citylearn.py:964-988`).
+- `normalize_observation` returns a numpy array of the **same length and
+  ordering** as `observation_names[index]`, scaled per
+  `simulator.entity_encoding`.
+
+### 6.2 Implication for v2
+
+There is **no encoded-dimension expansion**. Encoded index = raw feature
+position in `observation_names[building]`. The layout builder therefore
+records `feature_indices` directly as positions in
+`observation_names[building]`, and those same indices are used at slice
+time on the encoded tensor. We do **not** introduce an `encoded_index_map`
+parameter in v2 (it was an unnecessary abstraction in the first draft of
+this spec).
+
+### 6.3 When encoders are rebuilt
+
+Encoders (the placeholder list) are rebuilt from
+`Wrapper_CityLearn._apply_entity_layout` whenever `_apply_entity_layout`
+runs — i.e. on every reset and on every step that produces a new payload.
+The rebuild is cheap (it allocates one `NoNormalization()` per feature
+name). The agent’s layout rebuild, however, is gated on actual
+`topology_version` changes (see §12).
+
+---
+
+## 7. EntityTokenLayoutBuilder (replaces v1 ObservationEnricher)
+
+### 7.1 Responsibility
+
+Given the per-building `observation_names` (post-adapter, pre-encoding —
+which equals the post-encoding ordering, see §6.2), build a token segment
+table. Pure Python so it can be reused by the inference repo.
+
+### 7.2 Interface
+
+```python
+@dataclass(frozen=True)
+class TokenSegment:
+    family: str                          # "sro" | "nfc" | "ca"
+    type_name: str                       # e.g. "district_pricing_current",
+                                          #      "building_storage_state",
+                                          #      "pv", "ev_connected",
+                                          #      "storage", "charger"
+    instance_id: Optional[str]           # asset id (per-asset SRO / CA),
+                                          # building id (singleton SRO / NFC)
+    feature_indices: Tuple[int, ...]     # positions in observation_names
+                                          # (may be non-contiguous)
+    feature_names: Tuple[str, ...]
+    derived: Optional[NfcExpression] = None
+                                          # Only set on the NFC segment.
+                                          # Tells the tokenizer to compute a
+                                          # scalar from `feature_indices`
+                                          # (currently: subtract).
+
+
+@dataclass(frozen=True)
+class NfcExpression:
+    op: str                              # "subtract" (others reserved)
+    left_index_in_segment: int           # offset within feature_indices
+    right_index_in_segment: int
+
+
+@dataclass(frozen=True)
+class BuildingTokenLayout:
+    building_id: str
+    segments: Tuple[TokenSegment, ...]   # ordered: sros…, nfc, cas…
+    n_sro: int
+    n_ca: int                            # n_nfc is always 1
+    ca_action_names: Tuple[str, ...]     # action_field per CA segment, in
+                                          # segment order — equal to
+                                          # action_names[building] by
+                                          # construction.
+    excluded_feature_names: Tuple[str, ...]
+                                          # Features dropped before
+                                          # classification (see §5.4).
+
+
+class EntityTokenLayoutBuilder:
+    def __init__(self, tokenizer_config: Mapping[str, Any]) -> None: ...
+
+    def build(
+        self,
+        building_id: str,
+        observation_names: Sequence[str],
+        action_names: Sequence[str],
+    ) -> BuildingTokenLayout:
+        """Return the cached layout if (observation_names, action_names) matches,
+        else recompute. Owns CA ordering — see §7.3."""
+
+    def topology_changed(
+        self,
+        building_id: str,
+        observation_names: Sequence[str],
+        action_names: Sequence[str],
+    ) -> bool: ...
+```
+
+### 7.3 Classification rules
+
+For each building, in order:
+
+1. **Drop excluded features**: any name matching `excluded_features`
+   patterns (§5.4) is recorded in `excluded_feature_names` and skipped
+   from the rest of classification. The remaining names form the
+   classifier input.
+2. **Detect NFC**: locate the indices of all features named in
+   `nfc.expression` source fields (default:
+   `non_shiftable_load`, `solar_generation`). If any source feature is
+   missing → `ValueError`. If both are present, emit one
+   `TokenSegment(family="nfc", type_name="building",
+   instance_id=building_id, feature_indices=(idx_left, idx_right),
+   derived=NfcExpression(op="subtract", left_index_in_segment=0,
+   right_index_in_segment=1))`. These two source features are consumed
+   by NFC and not eligible for any SRO group.
+3. **Match SRO patterns**: for each remaining name, walk the SRO type
+   table and pick the unique match. The tokenizer JSON validation
+   guarantees uniqueness (§13.4 rule 2). Per-asset SRO types
+   (`pv`, `ev_connected`, `ev_incoming`) are matched by their adapter
+   prefix (e.g. `pv::<id>::…`); the `<id>` becomes the segment’s
+   `instance_id`. Singleton SRO types are scoped to the table prefix
+   (`district__…` for district-table SROs; unprefixed for
+   building-table SROs) and use `building_id` as `instance_id`.
+4. **Match CA prefixes**: `storage::<id>::…` → CA `storage`;
+   `charger::<id>::…` (with no `connected_ev`/`incoming_ev` segment) →
+   CA `charger`.
+5. **Reject leftovers**: any name that survives steps 1–4 unmatched →
+   `ValueError` listing the name and table-of-origin (recoverable from
+   the adapter prefix). This is the runtime mirror of the validation
+   rule in §13.4 rule 1; both must hard-fail to keep training and
+   inference layouts identical.
+
+Within each matched group, `feature_indices` are appended in the order
+the names appear in `observation_names`. Output ordering of `segments`:
+
+1. All SRO segments, sorted by `(sro_type_declaration_order_in_config,
+   instance_id)`. The declaration order in the tokenizer JSON is
+   stable, so this gives a deterministic SRO order (e.g.
+   `district_time` before `district_weather_current` before
+   `district_weather_forecast`, then per-asset SRO types sorted by
+   `instance_id`).
+2. The single NFC segment.
+3. All CA segments, ordered to **exactly match `action_names[building]`**
+   (see below).
+
+**CA ordering — single rule, single owner.** `EntityTokenLayoutBuilder`
+is the *only* component that decides CA segment order. For each CA
+candidate it derives the `action_field` from its `type_name` via the
+tokenizer config (`storage` ⇒ `electrical_storage`, `charger` ⇒
+`electric_vehicle_storage`) combined with the `instance_id`, then sorts
+the CA segments so that the resulting `ca_action_names` tuple is
+**element-wise equal to `action_names[building]`**. If no permutation
+satisfies that constraint (e.g. an action name has no matching CA
+candidate, or vice-versa), `build()` raises `ValueError` with both
+sequences in the message.
+
+This makes CA order *defined by `action_names[building]`* — there is no
+secondary sort key, no lexicographic fallback, no instance-id ordering.
+The startup check in §10.1 then becomes a pure post-condition assertion.
+
+### 7.4 Portability constraints
+
+- No imports from `algorithms.*`, `utils.*`, no torch/numpy.
+- Pure stdlib + `typing` + `re`.
+- File location: `algorithms/utils/entity_token_layout.py`.
+
+---
+
+## 8. EntityObservationTokenizer (replaces v1 marker tokenizer)
+
+### 8.1 Responsibility
+
+Slice the encoded per-building tensor into token groups using a
+`BuildingTokenLayout`, then project each group to `d_model` via per-type
+`Linear` layers. NFC is the special case: its segment carries an
+`NfcExpression` and is reduced to a scalar before projection.
+
+### 8.2 Interface
+
+```python
+@dataclass
+class TokenizedObservation:
+    sro_tokens: torch.Tensor    # [batch, N_sro, d_model]
+    nfc_token: torch.Tensor     # [batch, 1,     d_model]
+    ca_tokens: torch.Tensor     # [batch, N_ca,  d_model]
+    sro_types: List[str]        # one per SRO token (e.g. "district_pricing_current",
+                                # "pv", "ev_connected", …) — order = layout
+    ca_types: List[str]         # one per CA token (e.g. "storage", "charger") — order = layout
+    n_sro: int
+    n_ca: int
+
+
+class EntityObservationTokenizer(nn.Module):
+    def __init__(
+        self,
+        tokenizer_config: Mapping[str, Any],
+        d_model: int,
+        type_input_dims: Mapping[str, int],
+    ) -> None:
+        """Create one nn.Linear per type. type_input_dims maps every
+        declared type name (every SRO type, every CA type, plus the
+        single NFC type) to its raw feature count.
+
+        For SRO and CA types the input dim is taken from entity_specs at
+        attach time (see §8.5). For the NFC type the input dim is always
+        1 because the NfcExpression collapses its source features to a
+        scalar before projection."""
+
+    def forward(
+        self,
+        encoded_obs: torch.Tensor,        # [batch, obs_dim]
+        layout: BuildingTokenLayout,
+    ) -> TokenizedObservation: ...
+```
+
+### 8.3 Slicing implementation
+
+The tokenizer pre-registers, per segment, an `index_buffer = torch.tensor(
+segment.feature_indices, dtype=torch.long)` as a non-trainable buffer (so
+it follows the module to GPU). At forward time it does
+`group = encoded_obs.index_select(dim=1, index=index_buffer)`, which
+handles the non-contiguous case (e.g. forecasts interleaved with
+current-step features inside `district_weather_forecast`).
+
+For the **NFC segment specifically**, the tokenizer reads
+`segment.derived` (an `NfcExpression`), gathers the two source features
+via `index_select`, computes the configured op (currently only
+`subtract`: `nfc_scalar = group[..., left] - group[..., right]`),
+unsqueezes to shape `[batch, 1]`, then projects via
+`projections["building_nfc"]` → `[batch, d_model]`.
+
+### 8.4 Variable token counts (zero new parameters)
+
+A new charger reuses `projections["charger"]`. A new PV reuses
+`projections["pv"]`. A new building with the same `district` schema
+reuses every `projections["district_*"]`. Only the layout’s segment
+tuple grows — not the parameter set.
+
+### 8.5 Where input dimensions come from
+
+- **NFC**: always `1` (the scalar produced by `NfcExpression`). The
+  tokenizer config entry for NFC has no `input_dim_fallback` field —
+  the dim is hard-coded.
+- **CA types** (`storage`, `charger`): read from
+  `metadata["entity_specs"]["tables"]["<entity_table>"]["features"]`
+  at `attach_environment` time and use `len(features)`.
+- **Per-asset SRO types** (`pv`, `ev_connected`, `ev_incoming`): same
+  as CA — read from the corresponding `entity_table` (`pv`, `ev`).
+- **Singleton SRO types** (declared with `feature_patterns` against a
+  table such as `district` or `building`): the per-type input dim is
+  the count of features in that table that match the type’s
+  `feature_patterns` (computed once at `attach_environment` time using
+  `entity_specs.tables[<entity_table>].features`). For the
+  `building`-scoped SRO types the count is taken **after subtracting
+  excluded features and the NFC source features**.
+
+The tokenizer config provides `input_dim_fallback` per type for
+inference contexts where `entity_specs` is not available. Fallback
+values must equal the dim derived from `entity_specs`; mismatches raise
+`ValueError` listing both sides at instantiation. (NFC excepted as
+above.)
+
+---
+
+## 9. TransformerBackbone (reuse from `gj/plan-c`, extended)
+
+`gj/plan-c:algorithms/utils/transformer_backbone.py` is copied with two
+changes:
+
+- Type embedding table size = **3**: `SRO=0`, `NFC=1`, `CA=2`. (v1 had 3
+  for different families; the count happens to be unchanged but the
+  semantics differ. The CTX entry from earlier v2 drafts is **not**
+  introduced.)
+- `forward(sros, nfc, cas)` takes three tensors:
+  - `sros`: `[batch, N_sro, d_model]`
+  - `nfc`:  `[batch, 1,     d_model]`
+  - `cas`:  `[batch, N_ca,  d_model]`
+
+  Concatenates in fixed order `[sros…, nfc, cas…]` and slices
+  `ca_embeddings` at offsets `[N_sro + 1 : N_sro + 1 + N_ca]`. Mean
+  pooling for the critic spans **all** tokens (SRO + NFC + CA).
+
+Pre-LN, GELU, no positional embeddings — unchanged.
+
+---
+
+## 10. PPO Components & Action Contract
+
+### 10.1 CA token order ↔ action order
+
+CA order is owned exclusively by `EntityTokenLayoutBuilder.build()`,
+which receives `action_names[building]` and constructs `segments` so
+that `BuildingTokenLayout.ca_action_names == tuple(action_names[building])`
+by construction (see §7.3).
+
+`AgentTransformerPPO.predict()` returns one scalar per CA token, in the
+order produced by `BuildingTokenLayout.segments`. The wrapper then
+forwards that flat list to
+`EntityContractAdapter.to_entity_actions(actions, action_names)`. The
+adapter resolves each action *by name* via
+`action_names[building][position]`, so position-equality between
+`ca_action_names` and `action_names[building]` is exactly what the
+adapter requires.
+
+`attach_environment` performs a startup post-condition assertion
+(belt-and-braces; the builder already enforces it):
+
+```
+for b in range(len(action_names)):
+    expected = tuple(action_names[b])
+    actual = layout_builder.build(
+        building_id[b], observation_names[b], action_names[b]
+    ).ca_action_names
+    if expected != actual:
+        raise ValueError(
+            f"BuildingTokenLayout.ca_action_names {actual!r} does not match "
+            f"action_names[{b}] {expected!r}"
+        )
+```
+
+The same assertion runs inside `on_topology_change(b)` after the layout
+is rebuilt (see §12.2).
+
+### 10.2 Reused PPO modules (verbatim from `gj/plan-c`)
+
+- `ActorHead` — MLP per CA embedding; tanh-squashed Gaussian; learnable
+  shared `log_std` per CA *type*.
+- `CriticHead` — MLP from pooled embedding → scalar V(s).
+- `RolloutBuffer` — On-policy buffer with GAE.
+- `compute_ppo_loss` — Clipped surrogate + value loss + entropy bonus.
+
+### 10.3 Action range and clipping
+
+`predict()` returns values in `[-1, 1]`. The wrapper clips to per-agent
+action-space bounds via the existing `_clip_actions`
+(`utils/wrapper_citylearn.py:743-779`).
+
+---
+
+## 11. AgentTransformerPPO (v2)
+
+### 11.1 `BaseAgent` contract — exact signatures
+
+Copied from `algorithms/agents/base_agent.py:16-84`. Note `terminated` /
+`truncated` are **scalar booleans** (not lists), `output_dir` is `str`,
+`predict` returns `List[List[float]]`, and `attach_environment` uses
+keyword-only arguments.
+
+```python
+class AgentTransformerPPO(BaseAgent):
+    supports_dynamic_topology: ClassVar[bool] = True
+
+    def __init__(self, config: Dict[str, Any]) -> None: ...
+
+    def attach_environment(
+        self,
+        *,
+        observation_names: List[List[str]],
+        action_names: List[List[str]],
+        action_space: List[Any],
+        observation_space: List[Any],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Build per-building EntityObservationTokenizer / TransformerBackbone /
+        ActorHead / CriticHead / RolloutBuffer; store entity_specs; build the
+        initial BuildingTokenLayout per building; validate CA-order vs
+        action_names (see §10.1)."""
+
+    def predict(
+        self,
+        observations: List[npt.NDArray[np.float64]],
+        deterministic: Optional[bool] = None,
+    ) -> List[List[float]]: ...
+
+    def update(
+        self,
+        observations: List[npt.NDArray[np.float64]],
+        actions: List[npt.NDArray[np.float64]],
+        rewards: List[float],
+        next_observations: List[npt.NDArray[np.float64]],
+        terminated: bool,
+        truncated: bool,
+        *,
+        update_target_step: bool,
+        global_learning_step: int,
+        update_step: bool,
+        initial_exploration_done: bool,
+    ) -> None: ...
+
+    def on_topology_change(self, building_idx: int) -> None:
+        """Triggered by the wrapper after _entity_topology_version increments
+        (excluding the first attach — see §12.1).
+        1. If rollout buffer has data → run a PPO update on collected trajectory.
+        2. Clear the rollout buffer.
+        3. Rebuild the BuildingTokenLayout from new observation_names + action_names.
+        4. Re-run §13.4 rules 1–5 against new entity_specs (coverage,
+           uniqueness, NFC sources, pattern compilation, action-field coverage).
+        5. The §10.1 CA-order post-condition is implicit in rule 5."""
+
+    def export_artifacts(self, output_dir: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]: ...
+    def save_checkpoint(self, output_dir: str, step: int) -> Optional[str]: ...
+    def load_checkpoint(self, checkpoint_path: str) -> None: ...
+```
+
+### 11.2 Per-building structure
+
+Each building owns: tokenizer, backbone, actor, critic, rollout buffer,
+optimizer, cached `BuildingTokenLayout`. Same as v1.
+
+---
+
+## 12. Lifecycle: Reset, Topology Change, Buffer Flush, PPO
+
+This section makes the boundaries the reviewer asked for explicit.
+
+### 12.1 First attach (wrapper construction → `set_model`)
+
+The wrapper attaches the agent in **two stages** in the current code:
+
+1. `Wrapper_CityLearn.__init__` calls `_apply_entity_layout(payload,
+   force_attach=False)` (`utils/wrapper_citylearn.py:306`). At this
+   point `self.model is None`, so the inner
+   `_attach_model_environment_metadata()` short-circuits
+   (`utils/wrapper_citylearn.py:344-346`). The wrapper has populated
+   `observation_names`, `observation_space`, `action_space`,
+   `action_names`, `encoders`.
+2. `run_experiment.py` later instantiates the agent and calls
+   `wrapper.set_model(agent)`, which assigns `self.model = agent` and
+   immediately calls `_attach_model_environment_metadata()`
+   (`utils/wrapper_citylearn.py:418-423`). **This is the real first
+   `attach_environment(...)` invocation for the agent.**
+
+The Transformer agent therefore implements `attach_environment` so that
+it works in this order:
+
+1. Receive `observation_names`, `action_names`, `action_space`,
+   `observation_space`, and `metadata` (which contains
+   `entity_specs`, `interface`, `topology_mode`, `building_names`).
+2. Build per-building tokenizer / backbone / actor / critic / rollout
+   buffer / optimizer.
+3. Build layouts: `layouts[b] = layout_builder.build(building_id[b],
+   observation_names[b], action_names[b])`.
+4. Run the post-condition assertion in §10.1.
+5. Do **not** treat this as a topology change — buffers are empty by
+   definition; no PPO update is attempted.
+
+The agent MUST be tolerant of a second `attach_environment` call with
+identical `observation_names`/`action_names` (no-op, returns without
+mutation) because the wrapper may re-emit metadata on episode reset
+without a topology change.
+
+### 12.2 Genuine topology change mid-episode
+
+Call site: `Wrapper_CityLearn._apply_entity_layout`
+(`utils/wrapper_citylearn.py:309-342`) detects
+`previous_version is not None and self._entity_topology_version != previous_version`.
+
+The wrapper is the **single owner** of the rebuild trigger. The agent
+owns layout reconstruction. Sequence (must run in this order):
+
+1. Wrapper rebuilds `observation_names`, `observation_space`,
+   `action_space`, `action_names`, `encoders` (already happens at
+   `utils/wrapper_citylearn.py:317-326`).
+2. Wrapper calls `_attach_model_environment_metadata()` so the agent
+   sees the **new** `observation_names`/`action_names`/`entity_specs`
+   *before* it rebuilds layouts. (This replaces the existing call at
+   `utils/wrapper_citylearn.py:339-340`, which already runs in this
+   slot.)
+3. Wrapper calls
+   `TransformerObservationCoordinator.handle_topology_change(self)`,
+   which loops `for b in range(len(self.observation_names))` and calls
+   `agent.on_topology_change(b)`.
+4. Inside `on_topology_change(b)`:
+   a. If `rollout_buffer[b]` has data → run a single PPO update on the
+      collected trajectory using the **previous** layout (cached on the
+      agent until step 4c). PPO is on-policy and the data was collected
+      under the old policy/topology, so this is the only sound moment
+      to flush.
+   b. Clear `rollout_buffer[b]`.
+   c. Rebuild `layouts[b] = layout_builder.build(building_id[b],
+      observation_names[b], action_names[b])`. Re-pre-register
+      tokenizer index buffers.
+   d. Re-run §13.4 rules 1–5 against the new `entity_specs` (coverage,
+      uniqueness, NFC sources, pattern compilation already cached, action-
+      field coverage). Raise on any mismatch.
+   e. Re-run the §10.1 post-condition assertion.
+
+`attach_environment` does **not** rebuild layouts on its own when called
+during a topology change — the coordinator path above is the single
+entry point for layout rebuilds. This avoids the double-build that the
+reviewer flagged.
+
+> Edge case: a topology change in the middle of an unfinished
+> `update_step` window is handled here (the buffer is force-flushed). The
+> next regularly-scheduled `update_step` will then operate on a fresh
+> buffer.
+
+### 12.3 No-op steps
+
+When `_apply_entity_layout` runs but `topology_version` did not change, the
+coordinator does **nothing**. The agent does **not** rebuild layouts,
+buffers, or anything else.
+
+### 12.4 Dynamic-topology guardrail (generalised)
+
+The current MADDPG-specific raise (`utils/wrapper_citylearn.py:333-338` and
+`utils/config_schema.py:352-356`) is replaced by a single, generic rule:
+
+- Each agent class declares `supports_dynamic_topology: ClassVar[bool]`
+  (default `False`). `MADDPG` keeps `False`; `RuleBasedPolicy` is `True`
+  (it already works dynamically); `AgentTransformerPPO` is `True`.
+- `utils/config_schema.py` reads the registry at validation time and
+  raises if `simulator.topology_mode == "dynamic"` and the chosen
+  algorithm class has `supports_dynamic_topology is False`. The error
+  message keeps the existing wording for MADDPG to preserve test output.
+- `utils/wrapper_citylearn.py` keeps a runtime double-check (defence in
+  depth) but uses the same flag rather than a hard-coded `MADDPG` literal.
+
+---
+
+## 13. Configuration
+
+### 13.1 Tokenizer config
+
+`configs/tokenizers/entity_default.json`
+
+The config is the **single source of truth** for token taxonomy,
+feature exclusion, and NFC computation. Adding a new SRO grouping or
+removing a feature from the agent’s view is a config-only change — no
+code edit required.
+
+```json
+{
+  "type_embeddings": { "SRO": 0, "NFC": 1, "CA": 2 },
+
+  "excluded_features": {
+    "patterns": [
+      "^district__topology_version$",
+      "^electric_vehicle_charger_state$",
+      "^electric_vehicle_soc$",
+      "^electric_vehicle_required_soc_departure$",
+      "^electric_vehicle_departure_time$",
+      "^electric_vehicle_is_flexible$"
+    ]
+  },
+
+  "nfc": {
+    "type_name": "building_nfc",
+    "entity_table": "building",
+    "expression": {
+      "op": "subtract",
+      "left":  { "feature": "non_shiftable_load" },
+      "right": { "feature": "solar_generation" }
+    }
+  },
+
+  "ca_types": {
+    "storage": {
+      "entity_table": "storage",
+      "action_field": "electrical_storage",
+      "input_dim_fallback": 9
+    },
+    "charger": {
+      "entity_table": "charger",
+      "action_field": "electric_vehicle_storage",
+      "input_dim_fallback": 16
+    }
+  },
+
+  "sro_types": {
+    "district_time": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^district__month$",
+        "^district__day_type$",
+        "^district__hour$"
+      ],
+      "input_dim_fallback": 3
+    },
+    "district_weather_current": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^district__outdoor_dry_bulb_temperature$",
+        "^district__outdoor_relative_humidity$",
+        "^district__diffuse_solar_irradiance$",
+        "^district__direct_solar_irradiance$"
+      ],
+      "input_dim_fallback": 4
+    },
+    "district_weather_forecast": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^district__outdoor_dry_bulb_temperature_predicted_\\d+$",
+        "^district__outdoor_relative_humidity_predicted_\\d+$",
+        "^district__diffuse_solar_irradiance_predicted_\\d+$",
+        "^district__direct_solar_irradiance_predicted_\\d+$"
+      ],
+      "input_dim_fallback": 12
+    },
+    "district_carbon": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [ "^district__carbon_intensity$" ],
+      "input_dim_fallback": 1
+    },
+    "district_pricing_current": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [ "^district__electricity_pricing$" ],
+      "input_dim_fallback": 1
+    },
+    "district_pricing_forecast": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [ "^district__electricity_pricing_predicted_\\d+$" ],
+      "input_dim_fallback": 3
+    },
+    "district_community_energy": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^district__community_(net|import|export|pv|bess|ev)_(power_kw|energy_kwh_step)$"
+      ],
+      "input_dim_fallback": 12
+    },
+    "district_community_headroom": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^district__community_(building|phase)(_export)?_headroom_kw$"
+      ],
+      "input_dim_fallback": 4
+    },
+    "district_community_history": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^district__community_net_prev_\\d+_(kwh_step|mean_kwh_step)$"
+      ],
+      "input_dim_fallback": 2
+    },
+    "district_meta": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [ "^district__active_(buildings|chargers|evs)_count$" ],
+      "input_dim_fallback": 3
+    },
+
+    "building_storage_state": {
+      "entity_table": "building",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^electrical_storage_soc$",
+        "^electrical_storage_soc_ratio$"
+      ],
+      "input_dim_fallback": 2
+    },
+    "building_charging_phase_onehot": {
+      "entity_table": "building",
+      "cardinality": "singleton",
+      "feature_patterns": [ "^charging_phase_one_hot_.+$" ],
+      "input_dim_fallback": 6
+    },
+    "building_charging_headroom": {
+      "entity_table": "building",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^charging_(building|phase_L\\d+)(_export)?_headroom_kw$"
+      ],
+      "input_dim_fallback": 8
+    },
+    "building_charging_violation": {
+      "entity_table": "building",
+      "cardinality": "singleton",
+      "feature_patterns": [ "^charging_constraint_violation_kwh$" ],
+      "input_dim_fallback": 1
+    },
+    "building_energy_current": {
+      "entity_table": "building",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^net_electricity_consumption$",
+        "^(net|import|export|load|pv|bess|ev_charging)_(power_kw|energy_kwh_step)$"
+      ],
+      "input_dim_fallback": 15
+    },
+    "building_energy_history": {
+      "entity_table": "building",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^(net|import|export)_energy_prev_\\d+_(kwh_step|mean_kwh_step)$"
+      ],
+      "input_dim_fallback": 4
+    },
+    "building_meta": {
+      "entity_table": "building",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^active_chargers_count$",
+        "^active_storages_count$",
+        "^active_pvs_count$"
+      ],
+      "input_dim_fallback": 3
+    },
+
+    "pv": {
+      "entity_table": "pv",
+      "cardinality": "per_asset",
+      "adapter_prefix": "pv::",
+      "input_dim_fallback": 3
+    },
+    "ev_connected": {
+      "entity_table": "ev",
+      "cardinality": "per_asset",
+      "adapter_prefix": "charger::",
+      "adapter_label": "connected_ev",
+      "input_dim_fallback": 8
+    },
+    "ev_incoming": {
+      "entity_table": "ev",
+      "cardinality": "per_asset",
+      "adapter_prefix": "charger::",
+      "adapter_label": "incoming_ev",
+      "input_dim_fallback": 8
+    }
+  },
+
+  "validation": {
+    "unmatched_features": "fail",
+    "ambiguous_pattern_match": "fail",
+    "input_dim_mismatch": "fail"
+  }
+}
+```
+
+#### Coverage accounting (matches the sample payload exactly)
+
+Numbers below are derived from
+`datasets/tmp_entity_obs_full_step2200_named.json` (district 46,
+building 38).
+
+| Table | Bucket | Count |
+|---|---|---|
+| district | `district_time` | 3 |
+| district | `district_weather_current` | 4 |
+| district | `district_weather_forecast` | 12 |
+| district | `district_carbon` | 1 |
+| district | `district_pricing_current` | 1 |
+| district | `district_pricing_forecast` | 3 |
+| district | `district_community_energy` | 12 |
+| district | `district_community_headroom` | 4 |
+| district | `district_community_history` | 2 |
+| district | `district_meta` | 3 |
+| district | excluded (`topology_version`) | 1 |
+| **district total** | | **46** ✓ |
+| building | NFC sources (`non_shiftable_load`, `solar_generation`) | 2 |
+| building | `building_storage_state` | 2 |
+| building | `building_charging_phase_onehot` | 6 |
+| building | `building_charging_headroom` | 8 |
+| building | `building_charging_violation` | 1 |
+| building | `building_energy_current` | 15 |
+| building | `building_energy_history` | 4 |
+| **building table total** | | **38** ✓ |
+| Adapter-emitted trailing (per-building) | `building_meta` (`active_*_count`) | 3 |
+| Adapter-emitted trailing (per-building) | excluded (legacy charger aliases) | 4–5 |
+
+Per-asset SRO and CA token counts vary at runtime with topology.
+
+#### "Cardinality" semantics
+
+- `singleton` SRO types yield exactly **one token per building** (the
+  features matched by `feature_patterns` form one segment). Used for
+  district and building scoped groupings.
+- `per_asset` SRO types yield **N tokens per building** where N is
+  determined by the adapter prefix (`pv::<id>::…`,
+  `charger::<id>::connected_ev::…`, `charger::<id>::incoming_ev::…`).
+  One segment per matched `<id>`.
+
+#### NFC config
+
+The `nfc` block declares the **single** NFC token. `expression.op`
+must be one of: `subtract`. `left.feature` and `right.feature` must
+exist in the `entity_table`. The tokenizer collapses these two source
+features into a scalar at forward time (§8.3) — the source features
+do not appear in any SRO group (§7.3 step 2).
+
+To change the NFC definition (e.g. add a third term, or use a
+different expression), modify this block — no code change required.
+
+### 13.2 Algorithm template (full repo-valid shape)
+
+`configs/templates/transformer_ppo_entity_dynamic.yaml`
+
+```yaml
+metadata:
+  experiment_name: "transformer_ppo_entity_dynamic_template"
+  run_name: "Transformer PPO Entity Dynamic Local"
+  community_name: "default_community"
+  description: "Per-building Transformer PPO over entity interface with dynamic topology"
+
+runtime:
+  log_dir: null
+  job_dir: null
+  mlflow_uri: null
+  job_id: null
+  run_id: null
+  run_name: null
+  tracking_uri: null
+  experiment_id: null
+  mlflow_run_url: null
+
+tracking:
+  mlflow_enabled: true
+  log_level: "INFO"
+  log_frequency: 1
+  mlflow_step_sample_interval: 10
+  mlflow_artifacts_profile: minimal
+  progress_updates_enabled: true
+  progress_update_interval: 5
+  system_metrics_enabled: false
+  system_metrics_interval: 10
+
+checkpointing:
+  resume_training: false
+  checkpoint_run_id: null
+  checkpoint_artifact: "transformer_ppo_checkpoint.pt"
+  use_best_checkpoint_artifact: false
+  reset_replay_buffer: false
+  freeze_pretrained_layers: false
+  fine_tune: false
+  checkpoint_interval: null
+
+bundle:
+  bundle_version: null
+  description: null
+  alias_mapping_path: null
+  require_observations_envelope: false
+  artifact_config: {}
+  per_agent_artifact_config: {}
+
+simulator:
+  dataset_name: citylearn_three_phase_dynamic_assets_only_demo
+  dataset_path: ./datasets/citylearn_three_phase_dynamic_assets_only_demo/schema.json
+  central_agent: false
+  interface: entity
+  topology_mode: dynamic
+  entity_encoding:
+    enabled: true
+    normalization: minmax_space
+    clip: true
+  reward_function: RewardFunction
+  reward_function_kwargs: {}
+  episodes: 1
+  simulation_start_time_step: 0
+  simulation_end_time_step: 3400
+  episode_time_steps: 3401
+  export:
+    mode: end
+    export_kpis_on_episode_end: true
+    session_name: null
+  wrapper_reward:
+    enabled: false
+    profile: cost_limits_v1
+    clip_enabled: true
+    clip_min: -10.0
+    clip_max: 10.0
+    squash: none
+
+training:
+  seed: 22
+  steps_between_training_updates: 1
+  target_update_interval: 0
+
+topology:
+  num_agents: null
+  observation_dimensions: null
+  action_dimensions: null
+  action_space: null
+
+algorithm:
+  name: "AgentTransformerPPO"
+  tokenizer_config_path: configs/tokenizers/entity_default.json
+  transformer:
+    d_model: 64
+    nhead: 4
+    num_layers: 2
+    dim_feedforward: 128
+    dropout: 0.1
+  hyperparameters:
+    learning_rate: 3.0e-4
+    gamma: 0.99
+    gae_lambda: 0.95
+    clip_eps: 0.2
+    ppo_epochs: 4
+    minibatch_size: 64
+    entropy_coeff: 0.01
+    value_coeff: 0.5
+    max_grad_norm: 0.5
+  networks: null
+  replay_buffer: null
+  exploration: null
+
+execution: null
+```
+
+This template mirrors the field set of
+`configs/templates/rule_based_entity_dynamic_assets_only_local.yaml` so it
+will pass `validate_config(...)` without further plumbing.
+
+### 13.3 Hyperparameter naming (canonical)
+
+The single canonical name for the optimizer learning rate is
+**`learning_rate`** (matching v1 spec §9 and the YAML above). Internally the
+agent may alias `self.lr = self.config["algorithm"]["hyperparameters"]["learning_rate"]`,
+but no schema, config or docstring uses `lr` as the canonical key.
+
+### 13.4 Tokenizer JSON validation
+
+`utils/config_schema.py` is extended with `EntityTokenizerConfig` (Pydantic).
+After successfully loading a YAML config that names
+`AgentTransformerPPO`, `validate_config(...)` opens the file at
+`algorithm.tokenizer_config_path`, parses it as JSON, constructs
+`EntityTokenizerConfig.model_validate(...)`, and then enforces the
+following **five hard-fail rules** against a real entity-payload sample
+(loaded from the configured dataset, or from
+`datasets/tmp_entity_obs_full_step2200_named.json` if the simulator
+hasn't been instantiated yet):
+
+1. **Coverage.** Every feature in every `entity_table` referenced by
+   the tokenizer (district, building, plus per-asset tables) must be
+   either (a) matched by exactly one SRO type's `feature_patterns`,
+   (b) consumed by `nfc.expression`, or (c) matched by an
+   `excluded_features.patterns` entry. Unmatched features → `ValueError`
+   listing each unmatched feature, its source table, and the
+   recommended fix ("add to an existing SRO group, define a new SRO
+   type, or add to `excluded_features.patterns`").
+2. **Uniqueness.** No feature may match patterns from more than one
+   SRO type, or simultaneously match an SRO type and
+   `excluded_features.patterns`. Conflicts → `ValueError` listing the
+   feature, the matching SRO types / exclusion, and which patterns
+   matched.
+3. **NFC sources exist.** `nfc.expression.left.feature` and
+   `nfc.expression.right.feature` must appear in the tokenizer's
+   `nfc.entity_table`. Missing → `ValueError`.
+4. **Pattern compilation.** Each `feature_patterns` entry and every
+   `excluded_features.patterns` entry must compile as a Python regex
+   (`re.compile`). Bad regex → `ValueError` reporting the JSON path
+   and the regex error message.
+5. **Action-field coverage.** Every `ca_types[*].action_field` must
+   appear in `action_names[building]` for every building reported by
+   the dataset. Missing → `ValueError` (this is the existing §10.1
+   post-condition, generalised).
+
+These same rules also run at runtime inside `attach_environment` and
+`on_topology_change` against the live `entity_specs`, so feature
+additions / renames in a new dataset version trigger an explicit
+failure, not silent drops.
+
+Validation is performed in a single authoritative place
+(`validate_config`) — no caller may instantiate
+`AgentTransformerPPO` with a malformed tokenizer config.
+
+### 13.5 Schema additions summary
+
+- `EntityTokenizerConfig` — fields per §13.1:
+  - `type_embeddings: Mapping[Literal["SRO","NFC","CA"], int]` (must equal
+    `{"SRO": 0, "NFC": 1, "CA": 2}`).
+  - `excluded_features: ExcludedFeaturesConfig` (with `patterns: List[str]`).
+  - `nfc: NfcConfig` (`type_name`, `entity_table`, `expression`).
+  - `nfc.expression: NfcExpressionConfig` (`op: Literal["subtract"]`,
+    `left: NfcOperandConfig`, `right: NfcOperandConfig`).
+  - `ca_types: Mapping[str, CaTypeConfig]` with at minimum `storage` and
+    `charger`.
+  - `sro_types: Mapping[str, SroTypeConfig]` — values discriminated on
+    `cardinality: Literal["singleton","per_asset"]`. Singleton variants
+    require `feature_patterns: List[str]` and `entity_table: str`.
+    Per-asset variants require `entity_table: str`, `adapter_prefix: str`,
+    optional `adapter_label: str`.
+  - `validation: Mapping[str, Literal["fail"]]` — currently three keys:
+    `unmatched_features`, `ambiguous_pattern_match`,
+    `input_dim_mismatch`. All must be `"fail"` (no soft modes today —
+    reserved for the future).
+- `TransformerConfig` — `d_model`, `nhead`, `num_layers`, `dim_feedforward`,
+  `dropout` (positive ints / unit-interval floats).
+- `TransformerPPOHyperparameters` — `learning_rate`, `gamma`, `gae_lambda`,
+  `clip_eps`, `ppo_epochs`, `minibatch_size`, `entropy_coeff`,
+  `value_coeff`, `max_grad_norm`.
+- `TransformerPPOAlgorithmConfig` — `name: Literal["AgentTransformerPPO"]`,
+  `tokenizer_config_path: str`, `transformer: TransformerConfig`,
+  `hyperparameters: TransformerPPOHyperparameters`. Added to
+  `ProjectConfig.algorithm` discriminated union.
+- Generic dynamic-topology guardrail (replaces MADDPG-specific check, see
+  §12.4).
+
+---
+
+## 14. Export & Checkpoint Contract (dynamic topology)
+
+### 14.1 ONNX export
+
+Per-building, per call to `export_artifacts(output_dir, context=...)`. For
+each building `b`:
+
+- File: `<output_dir>/onnx_models/agent_<b>__topology_v<v>.onnx`
+  where `v` is `self._entity_topology_version_at_export`.
+- Inputs:
+  - `encoded_obs`: `Tensor[float32, (1, obs_dim_b)]` — obs_dim_b is the
+    current observation dimension for building `b`.
+  - `segment_offsets`: `Tensor[int64, (n_segments_b + 1,)]` — prefix-sum
+    index into a flattened concatenation of `feature_indices`. (We embed
+    the layout into the graph because ONNX has no native ragged-tuple
+    type.)
+  - `segment_indices`: `Tensor[int64, (sum_of_segment_sizes,)]`.
+- Output:
+  - `actions`: `Tensor[float32, (1, n_ca_b)]` — deterministic policy means.
+- Opset: 17, dynamic axes only on `obs_dim_b` (so the same file remains
+  valid if encoded length changes inside the same topology, which it
+  doesn’t today but is cheap to guard against).
+
+### 14.2 Manifest entries
+
+`export_artifacts` MUST return the canonical artifact payload required
+by `utils/artifact_manifest.py:69-84` and validated by
+`utils/bundle_validator.py:108-172`. The required keys are `format`
+(top-level) and `artifacts` (a non-empty list, one entry per building,
+each with `agent_index: int >= 0`, `path: str` pointing to a file that
+exists under `output_dir`, and a JSON-serialisable `config` object).
+For ONNX artifacts the file MUST end in `.onnx`. The number of entries
+in `artifacts` MUST equal `topology.num_agents` (set by
+`run_experiment.py:691-697` from the wrapper just before
+`export_artifacts` runs).
+
+Returned shape:
+
+```json
+{
+  "format": "onnx",
+  "artifacts": [
+    {
+      "agent_index": 0,
+      "path": "onnx_models/agent_0__topology_v7.onnx",
+      "format": "onnx",
+      "config": {
+        "building_id": "Building_1",
+        "topology_version": 7,
+        "obs_dim": 187,
+        "n_sro": 18,
+        "n_ca": 2,
+        "sro_types": [
+          "district_time", "district_weather_current",
+          "district_weather_forecast", "district_carbon",
+          "district_pricing_current", "district_pricing_forecast",
+          "district_community_energy", "district_community_headroom",
+          "district_community_history", "district_meta",
+          "building_storage_state", "building_charging_phase_onehot",
+          "building_charging_headroom", "building_charging_violation",
+          "building_energy_current", "building_energy_history",
+          "building_meta", "pv", "ev_connected"
+        ],
+        "ca_types": ["storage", "charger"]
+      }
+    }
+  ],
+  "tokenizer_config_path": "configs/tokenizers/entity_default.json",
+  "supports_dynamic_topology": true,
+  "agent_models": [
+    {
+      "building_index": 0,
+      "building_id": "Building_1",
+      "topology_version": 7,
+      "onnx_path": "onnx_models/agent_0__topology_v7.onnx",
+      "obs_dim": 187,
+      "n_sro": 18,
+      "n_ca": 2,
+      "sro_types": [
+        "district_time", "district_weather_current",
+        "district_weather_forecast", "district_carbon",
+        "district_pricing_current", "district_pricing_forecast",
+        "district_community_energy", "district_community_headroom",
+        "district_community_history", "district_meta",
+        "building_storage_state", "building_charging_phase_onehot",
+        "building_charging_headroom", "building_charging_violation",
+        "building_energy_current", "building_energy_history",
+        "building_meta", "pv", "ev_connected"
+      ],
+      "ca_types": ["storage", "charger"]
+    }
+  ]
+}
+```
+
+The `format` and `artifacts` fields are mandatory (validated by
+`bundle_validator`). The remaining fields (`tokenizer_config_path`,
+`supports_dynamic_topology`, `agent_models`) are supplemental metadata
+used by debugging and tooling and are passed through verbatim by
+`build_manifest` (`utils/artifact_manifest.py:41`).
+
+We export **only the topology version current at export time**; no
+cross-topology weight portability is required for production.
+
+### 14.3 Checkpoints
+
+- File: `<output_dir>/checkpoints/transformer_ppo_step<step>.pt`.
+- Payload (`torch.save`):
+  ```python
+  {
+    "step": int,
+    "topology_version": int,
+    "config": dict,        # the algorithm sub-config
+    "agents": [
+      {
+        "building_id": str,
+        "tokenizer_state": state_dict,
+        "backbone_state": state_dict,
+        "actor_state": state_dict,
+        "critic_state": state_dict,
+        "optimizer_state": state_dict,
+        "layout_signature": tuple[str, ...],   # sorted observation_names tuple
+      }
+    ],
+  }
+  ```
+- `load_checkpoint` rejects loading into a topology whose
+  `layout_signature` differs from the saved one, with an error pointing to
+  the field that disagrees. Cross-topology resumption is **not** supported.
+
+---
+
+## 15. File Structure & Work Packages
+
+### 15.1 Files
+
+(See §2 for the full delta. Summary view here.)
+
+```
+algorithms/
+├── agents/
+│   ├── transformer_ppo_agent.py                 # PORT from gj/plan-c, surgical edits
+│   └── transformer_ppo/
+│       ├── __init__.py                          # PORT
+│       ├── state_helper.py                      # PORT, drop marker registry
+│       ├── update_helper.py                     # PORT verbatim
+│       └── export_helper.py                     # PORT, drive shapes from layout
+├── utils/
+│   ├── entity_token_layout.py                   # NEW
+│   ├── entity_observation_tokenizer.py          # NEW
+│   ├── transformer_backbone.py                  # PORT, extend type embedding to 4
+│   └── ppo_components.py                        # PORT verbatim
+
+configs/
+├── tokenizers/
+│   └── entity_default.json                      # NEW
+└── templates/
+    └── transformer_ppo_entity_dynamic.yaml      # NEW
+
+utils/
+├── wrapper_citylearn.py                         # MODIFY (coordinator hook, generic guardrail)
+├── wrapper_transformer/
+│   ├── __init__.py                              # NEW
+│   └── transformer_observation_coordinator.py   # NEW
+└── config_schema.py                             # MODIFY (new models, JSON validation, generic guardrail)
+
+algorithms/registry.py                           # MODIFY (register AgentTransformerPPO)
+
+tests/
+├── test_entity_token_layout.py                  # NEW
+├── test_entity_observation_tokenizer.py         # NEW
+├── test_transformer_backbone.py                 # PORT + extend
+├── test_ppo_components.py                       # PORT
+├── test_agent_transformer_ppo_entity.py         # NEW
+├── test_wrapper_transformer_entity.py           # NEW
+└── test_e2e_transformer_ppo_entity_dynamic.py   # NEW
+
+docs/
+└── specv2.md                                    # this document
+```
+
+### 15.2 Work packages
+
+| WP | Component | Depends on | Deliverables |
+|----|---|---|---|
+| WP0 | Bring sources from `gj/plan-c` | — | Backbone, PPO components, helpers (see §2.2) |
+| WP1 | `EntityTokenLayoutBuilder` | — | `entity_token_layout.py` + tests |
+| WP2 | Tokenizer config + Pydantic schema + JSON validation | — | `entity_default.json`, `EntityTokenizerConfig`, validator hook |
+| WP3 | `EntityObservationTokenizer` | WP1, WP2 | `entity_observation_tokenizer.py` + tests |
+| WP4 | TransformerBackbone update (3-entry type embedding, new forward signature `(sros, nfc, cas)`) | WP0 | extended backbone + tests |
+| WP5 | PPO components verification | WP0 | re-run ported tests |
+| WP6 | `TransformerObservationCoordinator` | WP1 | coordinator + tests |
+| WP7 | Wrapper hooks + generic guardrail | WP6 | wrapper diff + integration tests |
+| WP8 | `AgentTransformerPPO` (CA-order check, attach lifecycle) | WP3, WP4, WP5, WP7 | agent + helpers + tests |
+| WP9 | Algorithm template, registry, schema additions | WP2, WP8 | yaml, registry, schema |
+| WP10 | E2E validation on `citylearn_three_phase_dynamic_assets_only_demo` | All | smoke test producing KPIs and ONNX |
+
+Parallelizable: WP0, WP1, WP2.
+
+---
+
+## 16. Test Plan
+
+### 16.1 `EntityTokenLayoutBuilder` (`tests/test_entity_token_layout.py`)
+
+| Test | Verifies |
+|---|---|
+| `test_classifies_district_time_to_sro_singleton` | `district__hour` → `(sro, "district_time", building_id)` |
+| `test_classifies_district_pricing_current_separately_from_forecast` | `district__electricity_pricing` → `district_pricing_current`; `district__electricity_pricing_predicted_2` → `district_pricing_forecast` |
+| `test_classifies_district_carbon_separately_from_pricing` | `district__carbon_intensity` → `district_carbon`, not `district_pricing_*` |
+| `test_classifies_building_storage_state_to_sro` | `electrical_storage_soc`, `electrical_storage_soc_ratio` → `(sro, "building_storage_state")` |
+| `test_classifies_per_asset_pv_to_sro` | `pv::Building_1/pv::generation_power_kw` → `(sro, "pv", "Building_1/pv")` |
+| `test_classifies_per_asset_ev_connected_to_sro` | `charger::B/c::connected_ev::soc` → `(sro, "ev_connected", "B/c")` |
+| `test_classifies_per_asset_ev_incoming_to_sro` | `charger::B/c::incoming_ev::soc` → `(sro, "ev_incoming", "B/c")` |
+| `test_classifies_storage_prefix_to_ca` | `storage::Building_1/electrical_storage::soc` → `(ca, "storage", "Building_1/electrical_storage")` |
+| `test_classifies_charger_prefix_to_ca` | `charger::B/c::connected_state` → `(ca, "charger", "B/c")` |
+| `test_nfc_segment_has_two_source_indices_and_subtract_op` | NFC segment has `feature_indices=(idx_nsl, idx_solar)`; `derived.op == "subtract"` |
+| `test_nfc_source_features_not_in_any_sro_group` | `non_shiftable_load` and `solar_generation` do not appear in any SRO segment’s `feature_names` |
+| `test_excluded_features_dropped_before_classification` | `district__topology_version` and legacy charger aliases appear in `excluded_feature_names` and not in any segment |
+| `test_unmatched_feature_raises` | Inject a never-seen feature `district__some_new_feature` → `ValueError` listing the feature and table |
+| `test_ambiguous_pattern_raises` | Two SRO types claim the same feature → `ValueError` |
+| `test_sro_segment_order_follows_config_declaration` | `district_time` segment appears before `district_weather_current`, etc. |
+| `test_per_asset_sro_segments_sorted_by_instance_id` | Two PVs → segments in lexicographic order of `instance_id` |
+| `test_segment_overall_order` | `[sros…, nfc, cas…sorted_by_action_position]` |
+| `test_topology_changed_when_names_differ` | Adding a new charger → True |
+| `test_topology_unchanged_for_identical_names` | False |
+| `test_layout_is_cached` | Repeated `build()` returns the same instance |
+| `test_no_external_imports` | Module imports only stdlib + typing + re |
+| `test_uses_real_sample_payload` | Build layout from `datasets/tmp_entity_obs_full_step2200_named.json` (passed through the adapter) succeeds for every building, with all 46 district + 38 building features accounted for |
+| `test_coverage_accounting_matches_spec` | Per-table feature counts in §13.1 coverage table are reproduced exactly |
+
+### 16.2 `EntityObservationTokenizer` (`tests/test_entity_observation_tokenizer.py`)
+
+| Test | Verifies |
+|---|---|
+| `test_forward_shapes_baseline` | sro_tokens=[1,N_sro,d], nfc_token=[1,1,d], ca_tokens=[1,N_ca,d] for the sample payload |
+| `test_forward_shapes_extra_charger` | ca_tokens=[1,2,d] when a second charger is present |
+| `test_projection_is_per_type_no_new_params_on_topology_grow` | Adding chargers / PVs does NOT add new parameters |
+| `test_index_select_handles_non_contiguous_sro_segment` | Mock encoded vector with sentinel values; verify `district_weather_forecast` slice gathers correct interleaved positions |
+| `test_nfc_token_value_equals_subtract_op` | Mock `non_shiftable_load=5.0`, `solar_generation=2.0` → NFC scalar = 3.0 (pre-projection) |
+| `test_nfc_input_dim_is_one` | `projections["building_nfc"].in_features == 1` |
+| `test_input_dim_mismatch_raises` | type_input_dims != entity_specs dim → clear ValueError naming both sides and the affected type |
+| `test_dtype_and_device_propagation` | Input cuda → output cuda; input float32 → output float32 |
+
+### 16.3 TransformerBackbone update (`tests/test_transformer_backbone.py`)
+
+| Test | Verifies |
+|---|---|
+| `test_type_embedding_table_size_3` | `nn.Embedding(3, d_model)` (SRO=0, NFC=1, CA=2) |
+| `test_concat_order_sros_nfc_cas` | First N_sro slots are sro tokens, slot N_sro is nfc, last block is ca |
+| `test_ca_embeddings_sliced_at_correct_offset` | Slice = `[N_sro + 1 : N_sro + 1 + N_ca]` |
+| `test_pooled_includes_sro_and_nfc_tokens` | Pooling spans all tokens (sros + nfc + cas) |
+| `test_gradient_flow_through_sro_tokens` | Backward through any sro token reaches the corresponding per-type projection |
+| `test_gradient_flow_through_nfc_token` | Backward through nfc reaches `projections["building_nfc"]` and the NfcExpression source indices |
+
+### 16.4 `AgentTransformerPPO` (`tests/test_agent_transformer_ppo_entity.py`)
+
+| Test | Verifies |
+|---|---|
+| `test_attach_environment_builds_layouts` | One `BuildingTokenLayout` per building, cached |
+| `test_attach_environment_validates_ca_action_order` | Mismatched `action_names` order raises |
+| `test_attach_environment_does_not_treat_first_call_as_topology_change` | No PPO update, no buffer flush |
+| `test_predict_action_count_matches_n_ca` | `len(actions[b]) == n_ca[b]` |
+| `test_predict_returns_list_of_lists_of_float` | Matches `BaseAgent.predict` signature |
+| `test_deterministic_uses_means` | Two deterministic calls → identical actions |
+| `test_stochastic_samples` | Two stochastic calls → different actions (>1e-6) |
+| `test_update_signature_uses_scalar_terminated_truncated` | Calling with `bool` works; calling with `List[bool]` raises a clear TypeError from upstream |
+| `test_update_returns_none` | Matches `BaseAgent.update` |
+| `test_on_topology_change_runs_update_then_flushes_buffer` | Buffer length == 0 after; PPO step counter incremented |
+| `test_on_topology_change_rebuilds_layout` | New layout reflects new observation_names |
+| `test_on_topology_change_validates_input_dim` | Raises if entity_specs dim != tokenizer dim |
+| `test_supports_dynamic_topology_flag` | `AgentTransformerPPO.supports_dynamic_topology is True` |
+| `test_checkpoint_round_trip_same_topology` | Save → load → identical weights |
+| `test_checkpoint_load_rejects_layout_signature_mismatch` | Loading into a different topology raises |
+
+### 16.5 Wrapper integration (`tests/test_wrapper_transformer_entity.py`)
+
+| Test | Verifies |
+|---|---|
+| `test_coordinator_initialised_only_for_transformer_agent` | `RuleBasedPolicy` doesn't trigger coordinator hooks |
+| `test_first_attach_does_not_trigger_topology_change` | `agent.on_topology_change` not called on initial reset |
+| `test_topology_version_increment_triggers_rebuild` | Mock env where `meta.topology_version` flips → encoders + layouts + agent rebuilds happen exactly once |
+| `test_topology_unchanged_does_not_rebuild` | Repeated steps with same `topology_version` → no rebuilds |
+| `test_action_conversion_uses_entity_adapter_tables_only` | Wrapper outputs `{"tables": {"building": ndarray, "charger": ndarray}}`; no `"map"` key |
+| `test_dynamic_guardrail_uses_supports_dynamic_topology_flag` | Setting flag to False on a dummy agent triggers the existing schema/runtime error; True does not |
+| `test_maddpg_dynamic_error_message_unchanged` | The exact MADDPG error string remains so existing tests continue to pass |
+
+### 16.6 Tokenizer JSON validation (`tests/test_entity_tokenizer_config_schema.py`)
+
+| Test | Verifies |
+|---|---|
+| `test_valid_json_loads` | The shipped `entity_default.json` validates against `EntityTokenizerConfig` and passes all 5 hard-fail rules on the sample payload |
+| `test_missing_ca_type_raises` | Removing `ca_types.charger` fails Pydantic validation |
+| `test_unknown_field_raises` | Extra unknown field at any level fails (strict mode) |
+| `test_validate_config_loads_tokenizer_json` | Top-level `validate_config(...)` invokes the JSON loader and reports the JSON path on failure |
+| `test_rule1_unmatched_feature_fails` | Add a fake feature `district__some_new_thing` to the sample payload → `ValueError` listing it |
+| `test_rule2_ambiguous_pattern_fails` | Two SRO types with overlapping patterns → `ValueError` listing the colliding feature and types |
+| `test_rule3_missing_nfc_source_fails` | Tokenizer references `nfc.expression.left.feature = "does_not_exist"` → `ValueError` |
+| `test_rule4_bad_regex_fails` | A `feature_patterns` entry like `"^[unclosed"` → `ValueError` reporting the JSON path and regex error |
+| `test_rule5_missing_action_field_fails` | Set `ca_types.charger.action_field = "no_such_action"` → `ValueError` |
+| `test_excluded_feature_pattern_removes_topology_version` | After validation, `district__topology_version` is in `excluded_feature_names` for every building |
+| `test_excluded_feature_cannot_match_an_sro_type` | Same feature in both `excluded_features.patterns` and an SRO `feature_patterns` → rule 2 conflict |
+
+### 16.7 End-to-end (`tests/test_e2e_transformer_ppo_entity_dynamic.py`)
+
+Run on `citylearn_three_phase_dynamic_assets_only_demo` for a small horizon.
+
+| Test | Verifies |
+|---|---|
+| `test_smoke_run_completes` | 200 steps, no crash |
+| `test_actions_in_valid_range` | All actions in `[-1, 1]`, no NaN |
+| `test_topology_changes_observed_during_run` | At least one `topology_version` increment in 200 steps (the assets-only demo guarantees this) |
+| `test_kpi_files_generated` | `runs/jobs/<id>/results/{result,summary}.json` exist |
+| `test_artifact_manifest_includes_onnx_per_building` | `artifact_manifest.json` lists per-building ONNX with the naming from §14.2 |
+| `test_buffer_flush_on_topology_change_does_not_crash` | The PPO update triggered by topology change runs and the agent continues training |
+
+---
+
+## 17. Decisions Log
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Token boundary signal | Per-feature origin prefixes emitted by `EntityContractAdapter`, classified once per topology by `EntityTokenLayoutBuilder`. No marker values in tensor. |
+| 2 | Topology-change detection | `meta.topology_version` increment, exclusively. No asset/feature counting. |
+| 3 | Per-building vs centralized | Per-building, like v1. |
+| 4 | Action payload | `{"tables": {"building": ndarray, "charger": ndarray}}` only. **No `"map"` field**, matching the current adapter (`utils/entity_adapter.py:548-552`). |
+| 5 | CA token order | Sorted by position in `action_names[building]`, validated at `attach_environment` and `on_topology_change`. |
+| 6 | Graph structure usage | Edges consumed by the wrapper for slicing only. The Transformer treats the result as a set of typed tokens. |
+| 7 | EV / PV handling | Per-asset SRO tokens. EV split into `ev_connected` and `ev_incoming` (matching `connected_ev` / `incoming_ev` adapter labels). PV is its own SRO type. |
+| 8 | RL algorithm | PPO, as in v1. Rollout buffer, GAE, clipped surrogate, K epochs. |
+| 9 | Encoder rebuilds | `set_encoders()` is called every `_apply_entity_layout`; cheap (placeholder `NoNormalization`). Agent layout rebuilds are gated on `topology_version` change. |
+| 10 | Type embeddings | 3 families: SRO, NFC, CA. CTX from earlier drafts collapsed into SRO with per-type projections distinguishing semantic groups. |
+| 21 | NFC scope | Strict: NFC = single scalar per building, value of `non_shiftable_load - solar_generation` computed by `NfcExpression`. Other building-table features become singleton SRO types (`building_storage_state`, `building_charging_*`, `building_energy_*`, `building_meta`). |
+| 22 | SRO grouping | Driven by `feature_patterns` (regex) in tokenizer JSON. District split into 10 semantic SROs (time, weather current/forecast, carbon, pricing current/forecast, community energy/headroom/history, meta). Pricing and carbon are separate. Current and forecast are separate. |
+| 23 | Feature exclusion | `excluded_features.patterns` in tokenizer JSON. Excludes `topology_version` (redundant with `meta`) and legacy charger aliases (redundant with per-charger CA tokens). Adding/removing features is config-only. |
+| 24 | Validation rules | Five hard-fail rules in §13.4 enforced both at config-validation time and at runtime on every topology change. No silent dropping of features. |
+| 11 | Reuse policy | Backbone, PPO components, helpers ported from `gj/plan-c@3e9a673`. Marker-based modules replaced. |
+| 12 | Cross-topology checkpoints/exports | Not supported. Checkpoint loader rejects layout-signature mismatch. ONNX file name encodes `topology_version`. |
+| 13 | Dynamic-topology guardrail | Replaced by generic `agent.supports_dynamic_topology` flag, enforced both in `validate_config` and at runtime. MADDPG error message preserved. |
+| 14 | Tokenizer input dims | Read from `entity_specs` at attach time; tokenizer config’s `input_dim_fallback` exists only for inference. |
+| 15 | Tokenizer JSON validation | Performed inside `validate_config(...)` after YAML validation succeeds. |
+| 16 | Hyperparameter naming | `learning_rate` is canonical. `lr` is never used as a config key. |
+| 17 | `terminated`/`truncated` types | Scalar `bool`, matching `BaseAgent.update` (`algorithms/agents/base_agent.py:33`). |
+| 18 | `attach_environment` arguments | Keyword-only, matching `BaseAgent.attach_environment` (`algorithms/agents/base_agent.py:58-65`). |
+| 19 | Encoder dimension expansion | Not supported in v2; encoded length equals raw `observation_names` length (current entity-mode behaviour). No `encoded_index_map`. |
+| 20 | Portability | `EntityTokenLayoutBuilder` stays pure-Python; `EntityObservationTokenizer` (torch) lives only in training repo. |

--- a/docs/specv2.md
+++ b/docs/specv2.md
@@ -1,7 +1,7 @@
 ## Universal Local Controller — Specification v2 (Entity Interface, Dynamic Topology)
 
 > Reference v1: `docs/spec.md` and `docs/implementation_summary.md`.
-> Sample observation payload: `datasets/tmp_entity_obs_full_step2200_named.json`.
+> Sample observation payload: `configs/tokenizers/fixtures/entity_obs_sample.json`.
 > Target dataset: `citylearn_three_phase_dynamic_assets_only_demo`.
 > Reusable v1 source code is **not** present on this branch. It lives on
 > branch `gj/plan-c` (pinned to commit
@@ -48,7 +48,7 @@ distinct embedding subspaces.
 ### 0.2 Authoritative feature names
 
 The regex catalogs in §13.1 are derived from
-`datasets/tmp_entity_obs_full_step2200_named.json` (district 46
+`configs/tokenizers/fixtures/entity_obs_sample.json` (district 46
 features, building 38, charger 16, ev 8, storage 9, pv 3). Any new
 dataset version that introduces feature names not matched by an
 existing pattern must hard-fail at config validation time (see §13.4
@@ -158,7 +158,7 @@ either copy them (preferred when reuse is verbatim) or rewrite them.
 
 ## 3. Entity Interface Data Format
 
-Sample: `datasets/tmp_entity_obs_full_step2200_named.json` (step 2200,
+Sample: `configs/tokenizers/fixtures/entity_obs_sample.json` (step 2200,
 `topology_version = 7`). The payload has three top-level fields: `tables`,
 `edges`, `meta`.
 
@@ -176,9 +176,26 @@ with `id` + values). Tables observed in the demo dataset:
 | `pv` | up to N | 3 | Per-building PV state | **SRO token** per PV (per-asset cardinality) |
 | `ev` | K | 8 | EV state (SOC, capacity, ratios) | **SRO token** per EV (split into `ev_connected` / `ev_incoming` per parent charger) |
 
-Counts above match `datasets/tmp_entity_obs_full_step2200_named.json` and
+Counts above match `configs/tokenizers/fixtures/entity_obs_sample.json` and
 must be reverified during implementation against the active dataset’s
 `entity_specs` (see §8.4).
+
+**When to regenerate the fixture.** The fixture is a snapshot of a real
+simulator payload; the tokenizer JSON declares which of those columns are
+SRO / NFC / CA / excluded, and `validate_config` runs the 5 hard-fail rules
+(§13.4) at config load against the fixture. **Regenerate the fixture
+whenever the simulator schema changes** (feature added/removed/renamed in
+any table, new asset type, adapter emission order changed). Run:
+
+```
+python scripts/dump_entity_obs_sample.py \
+    --config configs/templates/dynamic/transformer_ppo_entity_dynamic.yaml \
+    --output configs/tokenizers/fixtures/entity_obs_sample.json
+```
+
+If the new fixture uncovers uncovered features, `pytest tests/test_entity_tokenizer_config_schema.py`
+will fail with a rule 1 (coverage) violation — update the tokenizer JSON
+(`configs/tokenizers/entity_default.json`) to match, then re-run tests.
 
 ### 3.2 `edges`
 
@@ -1177,7 +1194,7 @@ code edit required.
 #### Coverage accounting (matches the sample payload exactly)
 
 Numbers below are derived from
-`datasets/tmp_entity_obs_full_step2200_named.json` (district 46,
+`configs/tokenizers/fixtures/entity_obs_sample.json` (district 46,
 building 38).
 
 | Table | Bucket | Count |
@@ -1364,7 +1381,7 @@ After successfully loading a YAML config that names
 `EntityTokenizerConfig.model_validate(...)`, and then enforces the
 following **five hard-fail rules** against a real entity-payload sample
 (loaded from the configured dataset, or from
-`datasets/tmp_entity_obs_full_step2200_named.json` if the simulator
+`configs/tokenizers/fixtures/entity_obs_sample.json` if the simulator
 hasn't been instantiated yet):
 
 1. **Coverage.** Every feature in every `entity_table` referenced by
@@ -1663,7 +1680,7 @@ Parallelizable: WP0, WP1, WP2.
 | `test_topology_unchanged_for_identical_names` | False |
 | `test_layout_is_cached` | Repeated `build()` returns the same instance |
 | `test_no_external_imports` | Module imports only stdlib + typing + re |
-| `test_uses_real_sample_payload` | Build layout from `datasets/tmp_entity_obs_full_step2200_named.json` (passed through the adapter) succeeds for every building, with all 46 district + 38 building features accounted for |
+| `test_uses_real_sample_payload` | Build layout from `configs/tokenizers/fixtures/entity_obs_sample.json` (passed through the adapter) succeeds for every building, with all 46 district + 38 building features accounted for |
 | `test_coverage_accounting_matches_spec` | Per-table feature counts in §13.1 coverage table are reproduced exactly |
 
 ### 16.2 `EntityObservationTokenizer` (`tests/test_entity_observation_tokenizer.py`)

--- a/docs/transformer_ppo_spec.md
+++ b/docs/transformer_ppo_spec.md
@@ -1630,7 +1630,7 @@ tests/
 └── test_e2e_transformer_ppo_entity_dynamic.py   # NEW
 
 docs/
-└── specv2.md                                    # this document
+└── transformer_ppo_spec.md                     # this document
 ```
 
 ### 15.2 Work packages

--- a/docs/transformer_ppo_spec.md
+++ b/docs/transformer_ppo_spec.md
@@ -1,32 +1,23 @@
-## Universal Local Controller — Specification v2 (Entity Interface, Dynamic Topology)
+## Universal Local Controller — Transformer-PPO Specification (Entity Interface, Dynamic Topology)
 
-> Reference v1: `docs/spec.md` and `docs/implementation_summary.md`.
 > Sample observation payload: `configs/tokenizers/fixtures/entity_obs_sample.json`.
 > Target dataset: `citylearn_three_phase_dynamic_assets_only_demo`.
-> Reusable v1 source code is **not** present on this branch. It lives on
-> branch `gj/plan-c` (pinned to commit
-> `3e9a6737d7306b04f3516738f86a98ea52106ef5`). Implementing agents must check
-> that branch out (or `git show gj/plan-c:<path>`) to read the v1 modules
-> referenced below as “reuse from `gj/plan-c`”.
-> **No legacy (`flat`) interface logic should be added.** Anything new must
-> use the `entity` interface and `topology_version`-based topology tracking
-> introduced in `softcpsrecsimulator 0.3.0`.
+> The `entity` interface and `topology_version`-based topology tracking
+> introduced in `softcpsrecsimulator 0.3.0` are the only supported code
+> paths; no legacy `flat` interface logic is added.
 
 ---
 
 ## 0. Conventions
 
 - File paths are repo-relative.
-- Line references are pinned to current `HEAD` of this branch unless prefixed
-  with `gj/plan-c:` (e.g. `gj/plan-c:algorithms/utils/transformer_backbone.py`).
 - The phrase “the wrapper” means `utils/wrapper_citylearn.py:Wrapper_CityLearn`.
 - The phrase “the adapter” means
   `utils/entity_adapter.py:EntityContractAdapter`.
 
 ### 0.1 Token-family vocabulary
 
-v2 has **three** token families (down from four in earlier drafts — CTX
-has been collapsed into SRO):
+The model uses **three** token families:
 
 | Family | Cardinality per building | Has action output? | Examples |
 |---|---|---|---|
@@ -36,22 +27,21 @@ has been collapsed into SRO):
 
 The type embedding table has **3** entries: `SRO=0`, `NFC=1`, `CA=2`.
 
-“CTX” no longer appears anywhere in the design. Per-asset read-only
-streams that earlier drafts called CTX (`pv`, `ev_connected`,
-`ev_incoming`) are now SRO **types** with `cardinality: per_asset` (see
-§7.3). Per-feature-group district splits (`district_pricing_current`,
-`district_weather_forecast`, …) are SRO types with
-`cardinality: singleton`. The Transformer treats them all the same way
-at attention time; the per-type `Linear` projection is what gives them
+Per-asset read-only streams (`pv`, `ev_connected`, `ev_incoming`) are SRO
+**types** with `cardinality: per_asset` (see §6.3). Per-feature-group
+district splits (`district_pricing_current`, `district_weather_forecast`,
+…) are SRO types with `cardinality: singleton`. The Transformer treats
+them all the same way at attention time; the per-type `Linear`
+projection is what gives them
 distinct embedding subspaces.
 
 ### 0.2 Authoritative feature names
 
-The regex catalogs in §13.1 are derived from
+The regex catalogs in §12.1 are derived from
 `configs/tokenizers/fixtures/entity_obs_sample.json` (district 46
 features, building 38, charger 16, ev 8, storage 9, pv 3). Any new
 dataset version that introduces feature names not matched by an
-existing pattern must hard-fail at config validation time (see §13.4
+existing pattern must hard-fail at config validation time (see §12.4
 rule 1). The recommended fix is documented in the error message.
 
 ---
@@ -76,11 +66,10 @@ runtime and without retraining:
   solar_generation`).
 The agent produces one action per CA token, so the CA order must be consistent between observation and action sides. SRO and NFC tokens have **no action outputs** but feed into shared self-attention so they shape every CA action.
 
-The end goal is identical to v1. What changes in v2 is **how data flows in
-and out of the agent**: the simulator now exposes a structured `entity`
-contract with explicit `meta.topology_version`, so we no longer need
-sentinel marker values to recover token boundaries, and we no longer use
-asset/feature counting to detect topology changes.
+The simulator exposes a structured `entity` contract with explicit
+`meta.topology_version`, so we do not use sentinel marker values to
+recover token boundaries and we do not use asset/feature counting to
+detect topology changes.
 
 ### Core Principles
 
@@ -96,73 +85,20 @@ asset/feature counting to detect topology changes.
    `np.ndarray` and returns a per-building `List[float]`. The wrapper
    translates between the simulator’s entity payload and these flat vectors
    in both directions via `EntityContractAdapter`.
-4. **Per-building agent.** Same architecture as v1 — independent
-   tokenizer / backbone / actor / critic / rollout buffer per building.
-5. **Reusable v1 components.** TransformerBackbone, ActorHead, CriticHead,
-   RolloutBuffer and the PPO loss are imported verbatim from `gj/plan-c`.
-   The marker-based ObservationEnricher and marker-scanning Tokenizer are
-   replaced by entity-aware modules.
-6. **Portability.** The new layout-builder module is pure-Python (stdlib +
+4. **Per-building agent.** Independent tokenizer / backbone / actor /
+   critic / rollout buffer per building.
+5. **Portability.** The layout-builder module is pure-Python (stdlib +
    typing only) so the production inference repo can reuse it without
    pulling Torch.
 
----
 
-## 2. Repo Delta from `gj/plan-c`
-
-### 2.1 What this checkout already has (entity side)
-
-| Path | Purpose | Lines |
-|---|---|---|
-| `utils/wrapper_citylearn.py` | Entity-mode detection, topology tracking, metadata attach, action conversion delegation | `:147-175`, `:309-365`, `:733-740` |
-| `utils/entity_adapter.py` | Per-building observation flattening (`to_agent_observations`) and flat→entity action conversion (`to_entity_actions`) | `:145-347`, `:486-552` |
-| `algorithms/agents/base_agent.py` | The exact agent contract this work must satisfy | `:16-84` |
-| `utils/config_schema.py` | Pydantic models, including the existing `topology_mode='dynamic'` ⇒ `interface='entity'` validator and the MADDPG-vs-`entity+dynamic` guardrail | `:117-118`, `:157-158`, `:344-356` |
-| `configs/templates/rule_based_entity_dynamic_assets_only_local.yaml` | Reference template shape we must mirror | full file |
-
-### 2.2 What is on `gj/plan-c` and **must be brought across or recreated**
-
-These files do **not** exist on this branch. The implementing agent must
-either copy them (preferred when reuse is verbatim) or rewrite them.
-
-| Path on `gj/plan-c` | Reuse policy in v2 |
-|---|---|
-| `algorithms/utils/transformer_backbone.py` | **Copy verbatim**, then update for v2 token families: 3-entry type embedding (`SRO=0, NFC=1, CA=2`) and `forward(sros, nfc, cas)` signature. |
-| `algorithms/utils/ppo_components.py` (Actor, Critic, RolloutBuffer, `compute_ppo_loss`) | **Copy verbatim.** No API change. |
-| `algorithms/agents/transformer_ppo/update_helper.py` | **Copy verbatim.** |
-| `algorithms/agents/transformer_ppo/export_helper.py` | Copy and adapt: input shape now derived from `BuildingTokenLayout`. |
-| `algorithms/agents/transformer_ppo/state_helper.py` | Copy, then **drop the marker registry**; add a `BuildingTokenLayout` field per building. |
-| `algorithms/agents/transformer_ppo_agent.py` | Copy, then surgically replace the enricher/marker-tokenizer wiring with the new entity layout/tokenizer. |
-| `algorithms/registry.py` change | Re-apply the `"AgentTransformerPPO"` registration. |
-
-### 2.3 Files created **net-new** in v2
-
-| Path | Purpose |
-|---|---|
-| `algorithms/utils/entity_token_layout.py` | Pure-Python `EntityTokenLayoutBuilder`, `BuildingTokenLayout`, `TokenSegment`. Replaces the v1 `ObservationEnricher`. |
-| `algorithms/utils/entity_observation_tokenizer.py` | Torch `EntityObservationTokenizer`. Replaces the v1 marker-scanning tokenizer. |
-| `utils/wrapper_transformer/__init__.py` + `transformer_observation_coordinator.py` | New coordinator hooks the layout builder into the wrapper’s entity lifecycle. |
-| `configs/tokenizers/entity_default.json` | New tokenizer config (entity-type based, no marker fields). |
-| `configs/templates/transformer_ppo_entity_dynamic.yaml` | New algorithm template; full repo-valid shape (see §13.2). |
-| Tests under `tests/` (see §16). | |
-
-### 2.4 Files modified
-
-| Path | Modification |
-|---|---|
-| `utils/wrapper_citylearn.py` | Add a `TransformerObservationCoordinator` hook (idempotent for non-Transformer agents). Generalise the `MADDPG`-specific dynamic guardrail (see §12.4). |
-| `utils/config_schema.py` | Add `EntityTokenizerConfig`, `TransformerConfig`, `TransformerPPOHyperparameters`, `TransformerPPOAlgorithmConfig`. Generalise the dynamic-topology guardrail to use a `supports_dynamic_topology` allow-list (keeping MADDPG’s rejection unchanged). Add JSON-validation for the file pointed to by `algorithm.tokenizer_config_path` (see §13.4). |
-| `algorithms/registry.py` | Register `"AgentTransformerPPO"`. |
-
----
-
-## 3. Entity Interface Data Format
+## 2. Entity Interface Data Format
 
 Sample: `configs/tokenizers/fixtures/entity_obs_sample.json` (step 2200,
 `topology_version = 7`). The payload has three top-level fields: `tables`,
 `edges`, `meta`.
 
-### 3.1 `tables`
+### 2.1 `tables`
 
 Each table has `features` (column names), `units`, and `rows` (list of dicts
 with `id` + values). Tables observed in the demo dataset:
@@ -178,12 +114,12 @@ with `id` + values). Tables observed in the demo dataset:
 
 Counts above match `configs/tokenizers/fixtures/entity_obs_sample.json` and
 must be reverified during implementation against the active dataset’s
-`entity_specs` (see §8.4).
+`entity_specs` (see §7.4).
 
 **When to regenerate the fixture.** The fixture is a snapshot of a real
 simulator payload; the tokenizer JSON declares which of those columns are
 SRO / NFC / CA / excluded, and `validate_config` runs the 5 hard-fail rules
-(§13.4) at config load against the fixture. **Regenerate the fixture
+(§12.4) at config load against the fixture. **Regenerate the fixture
 whenever the simulator schema changes** (feature added/removed/renamed in
 any table, new asset type, adapter emission order changed). Run:
 
@@ -197,7 +133,7 @@ If the new fixture uncovers uncovered features, `pytest tests/test_entity_tokeni
 will fail with a rule 1 (coverage) violation — update the tokenizer JSON
 (`configs/tokenizers/entity_default.json`) to match, then re-run tests.
 
-### 3.2 `edges`
+### 2.2 `edges`
 
 Topology graph; the wrapper consumes these to slice the global tables down
 to per-building views.
@@ -211,7 +147,7 @@ to per-building views.
 | `charger_to_ev_connected` (+ `_mask`) | Currently-connected EV per charger; `-1` = none. |
 | `charger_to_ev_incoming` (+ `_mask`) | Reserved/incoming EV per charger; `-1` = none. |
 
-### 3.3 `meta`
+### 2.3 `meta`
 
 ```json
 {
@@ -225,9 +161,9 @@ to per-building views.
 
 `topology_version` is the **single source of truth** for layout invalidation.
 
-### 3.4 Action contract (current ground truth)
+### 2.4 Action contract (current ground truth)
 
-The adapter (`utils/entity_adapter.py:486-552`) returns:
+The adapter (`utils/entity_adapter.py`) returns:
 
 ```python
 {
@@ -258,7 +194,7 @@ Source of truth for shape and ordering:
 
 ---
 
-## 4. End-to-End Data Flow
+## 3. End-to-End Data Flow
 
 ```
                                                       step()
@@ -282,8 +218,8 @@ Source of truth for shape and ordering:
  │      → self.encoders = self.set_encoders()      (placeholder NoNormalization)  │
  │      → wrapper._attach_model_environment_metadata()   (re-emits entity_specs   │
  │            + new observation_names + new action_names BEFORE layout rebuild)   │
- │      → coordinator.handle_topology_change(self) → for each building:           │
- │            agent.on_topology_change(b)                                         │
+ │      → agent.attach_environment(...) → detects per-building drift,           │
+ │            calls agent._handle_topology_change(b) internally:                 │
  │              ├─ flush rollout_buffer[b] (PPO update on previous layout)        │
  │              ├─ layouts[b] = layout_builder.build(                             │
  │              │      building_id[b], observation_names[b], action_names[b])    │
@@ -292,7 +228,7 @@ Source of truth for shape and ordering:
  │                                                                                │
  │ 3. agent.predict(encoded_obs, deterministic) → List[List[float]]               │
  │    where encoded_obs[b] = adapter.normalize_observation(b, raw_obs[b], ...)    │
- │    (see utils/wrapper_citylearn.py:964-988 — current behaviour)                │
+ │    (see utils/wrapper_citylearn.py — current behaviour)                │
  │                                                                                │
  │ 4. EntityContractAdapter.to_entity_actions(actions, action_names)              │
  │    → {"tables": {"building": np.ndarray, "charger": np.ndarray}}               │
@@ -326,56 +262,56 @@ Source of truth for shape and ordering:
 
 > Reminder: although the entity payload is community-wide, the
 > `EntityContractAdapter` already produces **one flat vector per building**
-> (`utils/entity_adapter.py:145`). The agent therefore stays per-building.
+> (`utils/entity_adapter.py`). The agent therefore stays per-building.
 
 ---
 
-## 5. Definitive Observation Contract
+## 4. Definitive Observation Contract
 
 This section is the authoritative reference for the layout builder and
 tokenizer tests. It mirrors the emission order of
-`EntityContractAdapter.to_agent_observations` (`utils/entity_adapter.py:213-329`).
+`EntityContractAdapter.to_agent_observations` (`utils/entity_adapter.py`).
 
-### 5.1 Per-building emission order
+### 4.1 Per-building emission order
 
 For each building `b` (in district-to-building edge order), names are
 appended to `observation_names[b]` in this exact order:
 
 1. **District block** — one feature per `district` table column, prefixed
-   `district__<feature>` (`utils/entity_adapter.py:215`).
+   `district__<feature>` (`utils/entity_adapter.py`).
 2. **Building block** — one feature per `building` table column,
-   **unprefixed** (`utils/entity_adapter.py:223`). Example names from the
+   **unprefixed** (`utils/entity_adapter.py`). Example names from the
    sample payload: `non_shiftable_load`, `solar_generation`,
    `electrical_storage_soc`, `net_electricity_consumption`,
    `charging_phase_one_hot_charger_15_1_L1`, …
 3. **Per-storage blocks** — for each storage row attached to this building,
    prefixed `storage::<storage_id>::<feature>`
-   (`utils/entity_adapter.py:239`).
+   (`utils/entity_adapter.py`).
 4. **Per-PV blocks** — for each PV row attached to this building, prefixed
-   `pv::<pv_id>::<feature>` (`utils/entity_adapter.py:250`).
+   `pv::<pv_id>::<feature>` (`utils/entity_adapter.py`).
 5. **Per-charger blocks**, in this order per charger
-   (`utils/entity_adapter.py:258-296`):
+   (`utils/entity_adapter.py`):
    1. Charger features prefixed `charger::<charger_id>::<feature>`.
    2. Connected-EV context features prefixed
       `charger::<charger_id>::connected_ev::<feature>`. **The label is
-      exactly `connected_ev`** (`utils/entity_adapter.py:291`).
+      exactly `connected_ev`** (`utils/entity_adapter.py`).
    3. Incoming-EV context features prefixed
       `charger::<charger_id>::incoming_ev::<feature>`. **The label is
-      exactly `incoming_ev`** (`utils/entity_adapter.py:294`).
+      exactly `incoming_ev`** (`utils/entity_adapter.py`).
 6. **Active-counters block** — three unprefixed features:
    `active_chargers_count`, `active_storages_count`, `active_pvs_count`
-   (`utils/entity_adapter.py:298-300`).
+   (`utils/entity_adapter.py`).
 7. **Legacy-charger-aliases block** — zero or more unprefixed features whose
    names come from `EntityContractAdapter._LEGACY_CHARGER_ALIASES`
-   (`utils/entity_adapter.py:302-329`). These are RBC-compatibility aliases
+   (`utils/entity_adapter.py`). These are RBC-compatibility aliases
    sourced from the building’s first connected charger. **In v2 these are
-   excluded from the token catalog** (see §5.4 / §13.1
+   excluded from the token catalog** (see §4.4 / §12.1
    `excluded_features`); they remain in `observation_names` for adapter
    compatibility but are not bound to any token.
 
-### 5.2 Token-family classification
+### 4.2 Token-family classification
 
-Classification is **regex-driven and config-driven** (see §13.1 for the
+Classification is **regex-driven and config-driven** (see §12.1 for the
 full tokenizer JSON). The high-level rule per feature is:
 
 | Feature pattern | Family | Type name | Instance id | Notes |
@@ -385,13 +321,13 @@ full tokenizer JSON). The high-level rule per feature is:
 | `storage::<id>::<feature>` | `ca` | `storage` | `<id>` | Action `electrical_storage`. |
 | `charger::<id>::<feature>` (no `connected_ev`/`incoming_ev` segment) | `ca` | `charger` | `<id>` | Action `electric_vehicle_storage`. |
 | Matches `nfc.expression` source features (`non_shiftable_load`, `solar_generation`) | `nfc` | `building` | `<building_id>` | Two source features collapse into **one** scalar token via the configured expression. |
-| Matches `excluded_features` patterns | (excluded) | — | — | Removed before classification (see §5.4). |
-| Anything else | (error) | — | — | Hard-fail at validation (§13.4 rule 1). |
+| Matches `excluded_features` patterns | (excluded) | — | — | Removed before classification (see §4.4). |
+| Anything else | (error) | — | — | Hard-fail at validation (§12.4 rule 1). |
 
 Notes:
 
 - **One feature → one match**: tokenizer JSON validation rule 2
-  (uniqueness, §13.4) guarantees no feature is matched by patterns from
+  (uniqueness, §12.4) guarantees no feature is matched by patterns from
   more than one SRO type.
 - **NFC is a scalar**: the NFC token has dim 1 — the value of
   `non_shiftable_load - solar_generation`. The two source features are
@@ -400,26 +336,26 @@ Notes:
   `feature_patterns` (for table-scoped SRO types) or
   `len(entity_specs.tables[<entity_table>].features)` (for per-asset
   SRO types). This count is fixed per topology and used to size the
-  per-type `Linear` projection (§8).
+  per-type `Linear` projection (§7).
 - **Non-contiguous indices**: an SRO type’s feature positions in
   `observation_names` may be non-contiguous (e.g.
   `district_weather_forecast` mixes `outdoor_dry_bulb_temperature_predicted_*`
   and `direct_solar_irradiance_predicted_*`). The layout records the
   full index list per group; the tokenizer slices via
-  `torch.index_select` (§8.3).
+  `torch.index_select` (§7.3).
 
-### 5.3 Why no marker injection
+### 4.3 Why no marker injection
 
-v1 used numeric markers because the legacy `flat` interface emitted a single
-unstructured vector. With `interface=entity`, the wrapper already emits
-deterministic per-feature names (see §5.1). We classify them once per
-topology via the regex catalog (§13.1) and slice the encoded tensor at
-fixed integer indices every step.
+With `interface=entity`, the wrapper emits deterministic per-feature
+names (see §4.1). We classify them once per topology via the regex
+catalog (§12.1) and slice the encoded tensor at fixed integer indices
+every step. No sentinel numeric markers are injected into the
+observation tensor.
 
-### 5.4 Excluded features
+### 4.4 Excluded features
 
 The tokenizer config carries an `excluded_features` list of patterns
-(see §13.1). Features matching any pattern are removed *before*
+(see §12.1). Features matching any pattern are removed *before*
 classification. Use cases:
 
 - **`topology_version`** (in the district table) — already conveyed via
@@ -428,7 +364,7 @@ classification. Use cases:
   `electric_vehicle_soc`, `electric_vehicle_required_soc_departure`,
   `electric_vehicle_departure_time`, `electric_vehicle_is_flexible`)
   emitted by `EntityContractAdapter._LEGACY_CHARGER_ALIASES`
-  (`utils/entity_adapter.py:302-321`) — kept for RBC compatibility but
+  (`utils/entity_adapter.py`) — kept for RBC compatibility but
   redundant with the per-charger CA tokens for the Transformer.
 
 This is the primary "feature engineering" knob: to remove a feature
@@ -441,53 +377,51 @@ travel with the model (training and inference must agree).
 
 ---
 
-## 6. Encoding Story (entity mode)
+## 5. Encoding Story (entity mode)
 
 This is intentionally minimal in the current code base.
 
-### 6.1 Current behaviour
+### 5.1 Current behaviour
 
 - `Wrapper_CityLearn.set_encoders()` returns a list of `NoNormalization()`
   placeholders when `interface=entity`
-  (`utils/wrapper_citylearn.py:1100-1108`).
+  (`utils/wrapper_citylearn.py`).
 - `Wrapper_CityLearn.get_encoded_observations(index, observations)` ignores
   those placeholders and instead delegates to
   `EntityContractAdapter.normalize_observation(...)`
-  (`utils/wrapper_citylearn.py:964-988`).
+  (`utils/wrapper_citylearn.py`).
 - `normalize_observation` returns a numpy array of the **same length and
   ordering** as `observation_names[index]`, scaled per
   `simulator.entity_encoding`.
 
-### 6.2 Implication for v2
+### 5.2 Implication for v2
 
 There is **no encoded-dimension expansion**. Encoded index = raw feature
 position in `observation_names[building]`. The layout builder therefore
 records `feature_indices` directly as positions in
 `observation_names[building]`, and those same indices are used at slice
-time on the encoded tensor. We do **not** introduce an `encoded_index_map`
-parameter in v2 (it was an unnecessary abstraction in the first draft of
-this spec).
+time on the encoded tensor. There is no `encoded_index_map` parameter.
 
-### 6.3 When encoders are rebuilt
+### 5.3 When encoders are rebuilt
 
 Encoders (the placeholder list) are rebuilt from
 `Wrapper_CityLearn._apply_entity_layout` whenever `_apply_entity_layout`
 runs — i.e. on every reset and on every step that produces a new payload.
 The rebuild is cheap (it allocates one `NoNormalization()` per feature
 name). The agent’s layout rebuild, however, is gated on actual
-`topology_version` changes (see §12).
+`topology_version` changes (see §11).
 
 ---
 
-## 7. EntityTokenLayoutBuilder (replaces v1 ObservationEnricher)
+## 6. EntityTokenLayoutBuilder
 
-### 7.1 Responsibility
+### 6.1 Responsibility
 
 Given the per-building `observation_names` (post-adapter, pre-encoding —
-which equals the post-encoding ordering, see §6.2), build a token segment
+which equals the post-encoding ordering, see §5.2), build a token segment
 table. Pure Python so it can be reused by the inference repo.
 
-### 7.2 Interface
+### 6.2 Interface
 
 ```python
 @dataclass(frozen=True)
@@ -528,7 +462,7 @@ class BuildingTokenLayout:
                                           # construction.
     excluded_feature_names: Tuple[str, ...]
                                           # Features dropped before
-                                          # classification (see §5.4).
+                                          # classification (see §4.4).
 
 
 class EntityTokenLayoutBuilder:
@@ -541,7 +475,7 @@ class EntityTokenLayoutBuilder:
         action_names: Sequence[str],
     ) -> BuildingTokenLayout:
         """Return the cached layout if (observation_names, action_names) matches,
-        else recompute. Owns CA ordering — see §7.3."""
+        else recompute. Owns CA ordering — see §6.3."""
 
     def topology_changed(
         self,
@@ -551,12 +485,12 @@ class EntityTokenLayoutBuilder:
     ) -> bool: ...
 ```
 
-### 7.3 Classification rules
+### 6.3 Classification rules
 
 For each building, in order:
 
 1. **Drop excluded features**: any name matching `excluded_features`
-   patterns (§5.4) is recorded in `excluded_feature_names` and skipped
+   patterns (§4.4) is recorded in `excluded_feature_names` and skipped
    from the rest of classification. The remaining names form the
    classifier input.
 2. **Detect NFC**: locate the indices of all features named in
@@ -570,7 +504,7 @@ For each building, in order:
    by NFC and not eligible for any SRO group.
 3. **Match SRO patterns**: for each remaining name, walk the SRO type
    table and pick the unique match. The tokenizer JSON validation
-   guarantees uniqueness (§13.4 rule 2). Per-asset SRO types
+   guarantees uniqueness (§12.4 rule 2). Per-asset SRO types
    (`pv`, `ev_connected`, `ev_incoming`) are matched by their adapter
    prefix (e.g. `pv::<id>::…`); the `<id>` becomes the segment’s
    `instance_id`. Singleton SRO types are scoped to the table prefix
@@ -582,7 +516,7 @@ For each building, in order:
 5. **Reject leftovers**: any name that survives steps 1–4 unmatched →
    `ValueError` listing the name and table-of-origin (recoverable from
    the adapter prefix). This is the runtime mirror of the validation
-   rule in §13.4 rule 1; both must hard-fail to keep training and
+   rule in §12.4 rule 1; both must hard-fail to keep training and
    inference layouts identical.
 
 Within each matched group, `feature_indices` are appended in the order
@@ -611,26 +545,54 @@ sequences in the message.
 
 This makes CA order *defined by `action_names[building]`* — there is no
 secondary sort key, no lexicographic fallback, no instance-id ordering.
-The startup check in §10.1 then becomes a pure post-condition assertion.
+The startup check in §9.1 then becomes a pure post-condition assertion.
 
-### 7.4 Portability constraints
+### 6.4 Portability constraints
 
 - No imports from `algorithms.*`, `utils.*`, no torch/numpy.
 - Pure stdlib + `typing` + `re`.
 - File location: `algorithms/utils/entity_token_layout.py`.
 
+### Tests (`tests/test_entity_token_layout.py`)
+
+| Test | Verifies |
+|---|---|
+| `test_classifies_district_time_to_sro_singleton` | `district__hour` → `(sro, "district_time", building_id)` |
+| `test_classifies_district_pricing_current_separately_from_forecast` | `district__electricity_pricing` → `district_pricing_current`; `district__electricity_pricing_predicted_2` → `district_pricing_forecast` |
+| `test_classifies_district_carbon_separately_from_pricing` | `district__carbon_intensity` → `district_carbon`, not `district_pricing_*` |
+| `test_classifies_building_storage_state_to_sro` | `electrical_storage_soc`, `electrical_storage_soc_ratio` → `(sro, "building_storage_state")` |
+| `test_classifies_per_asset_pv_to_sro` | `pv::Building_1/pv::generation_power_kw` → `(sro, "pv", "Building_1/pv")` |
+| `test_classifies_per_asset_ev_connected_to_sro` | `charger::B/c::connected_ev::soc` → `(sro, "ev_connected", "B/c")` |
+| `test_classifies_per_asset_ev_incoming_to_sro` | `charger::B/c::incoming_ev::soc` → `(sro, "ev_incoming", "B/c")` |
+| `test_classifies_storage_prefix_to_ca` | `storage::Building_1/electrical_storage::soc` → `(ca, "storage", "Building_1/electrical_storage")` |
+| `test_classifies_charger_prefix_to_ca` | `charger::B/c::connected_state` → `(ca, "charger", "B/c")` |
+| `test_nfc_segment_has_two_source_indices_and_subtract_op` | NFC segment has `feature_indices=(idx_nsl, idx_solar)`; `derived.op == "subtract"` |
+| `test_nfc_source_features_not_in_any_sro_group` | `non_shiftable_load` and `solar_generation` do not appear in any SRO segment’s `feature_names` |
+| `test_excluded_features_dropped_before_classification` | `district__topology_version` and legacy charger aliases appear in `excluded_feature_names` and not in any segment |
+| `test_unmatched_feature_raises` | Inject a never-seen feature `district__some_new_feature` → `ValueError` listing the feature and table |
+| `test_ambiguous_pattern_raises` | Two SRO types claim the same feature → `ValueError` |
+| `test_sro_segment_order_follows_config_declaration` | `district_time` segment appears before `district_weather_current`, etc. |
+| `test_per_asset_sro_segments_sorted_by_instance_id` | Two PVs → segments in lexicographic order of `instance_id` |
+| `test_segment_overall_order` | `[sros…, nfc, cas…sorted_by_action_position]` |
+| `test_topology_changed_when_names_differ` | Adding a new charger → True |
+| `test_topology_unchanged_for_identical_names` | False |
+| `test_layout_is_cached` | Repeated `build()` returns the same instance |
+| `test_no_external_imports` | Module imports only stdlib + typing + re |
+| `test_uses_real_sample_payload` | Build layout from `configs/tokenizers/fixtures/entity_obs_sample.json` (passed through the adapter) succeeds for every building, with all 46 district + 38 building features accounted for |
+| `test_coverage_accounting_matches_spec` | Per-table feature counts in §12.1 coverage table are reproduced exactly |
+
 ---
 
-## 8. EntityObservationTokenizer (replaces v1 marker tokenizer)
+## 7. EntityObservationTokenizer
 
-### 8.1 Responsibility
+### 7.1 Responsibility
 
 Slice the encoded per-building tensor into token groups using a
 `BuildingTokenLayout`, then project each group to `d_model` via per-type
 `Linear` layers. NFC is the special case: its segment carries an
 `NfcExpression` and is reduced to a scalar before projection.
 
-### 8.2 Interface
+### 7.2 Interface
 
 ```python
 @dataclass
@@ -657,7 +619,7 @@ class EntityObservationTokenizer(nn.Module):
         single NFC type) to its raw feature count.
 
         For SRO and CA types the input dim is taken from entity_specs at
-        attach time (see §8.5). For the NFC type the input dim is always
+        attach time (see §7.5). For the NFC type the input dim is always
         1 because the NfcExpression collapses its source features to a
         scalar before projection."""
 
@@ -668,7 +630,7 @@ class EntityObservationTokenizer(nn.Module):
     ) -> TokenizedObservation: ...
 ```
 
-### 8.3 Slicing implementation
+### 7.3 Slicing implementation
 
 The tokenizer pre-registers, per segment, an `index_buffer = torch.tensor(
 segment.feature_indices, dtype=torch.long)` as a non-trainable buffer (so
@@ -684,14 +646,14 @@ via `index_select`, computes the configured op (currently only
 unsqueezes to shape `[batch, 1]`, then projects via
 `projections["building_nfc"]` → `[batch, d_model]`.
 
-### 8.4 Variable token counts (zero new parameters)
+### 7.4 Variable token counts (zero new parameters)
 
 A new charger reuses `projections["charger"]`. A new PV reuses
 `projections["pv"]`. A new building with the same `district` schema
 reuses every `projections["district_*"]`. Only the layout’s segment
 tuple grows — not the parameter set.
 
-### 8.5 Where input dimensions come from
+### 7.5 Where input dimensions come from
 
 - **NFC**: always `1` (the scalar produced by `NfcExpression`). The
   tokenizer config entry for NFC has no `input_dim_fallback` field —
@@ -715,17 +677,26 @@ values must equal the dim derived from `entity_specs`; mismatches raise
 `ValueError` listing both sides at instantiation. (NFC excepted as
 above.)
 
+### Tests (`tests/test_entity_observation_tokenizer.py`)
+
+| Test | Verifies |
+|---|---|
+| `test_forward_shapes_baseline` | sro_tokens=[1,N_sro,d], nfc_token=[1,1,d], ca_tokens=[1,N_ca,d] for the sample payload |
+| `test_forward_shapes_extra_charger` | ca_tokens=[1,2,d] when a second charger is present |
+| `test_projection_is_per_type_no_new_params_on_topology_grow` | Adding chargers / PVs does NOT add new parameters |
+| `test_index_select_handles_non_contiguous_sro_segment` | Mock encoded vector with sentinel values; verify `district_weather_forecast` slice gathers correct interleaved positions |
+| `test_nfc_token_value_equals_subtract_op` | Mock `non_shiftable_load=5.0`, `solar_generation=2.0` → NFC scalar = 3.0 (pre-projection) |
+| `test_nfc_input_dim_is_one` | `projections["building_nfc"].in_features == 1` |
+| `test_input_dim_mismatch_raises` | type_input_dims != entity_specs dim → clear ValueError naming both sides and the affected type |
+| `test_dtype_and_device_propagation` | Input cuda → output cuda; input float32 → output float32 |
+
 ---
 
-## 9. TransformerBackbone (reuse from `gj/plan-c`, extended)
+## 8. TransformerBackbone
 
-`gj/plan-c:algorithms/utils/transformer_backbone.py` is copied with two
-changes:
+`algorithms/utils/transformer_backbone.py`:
 
-- Type embedding table size = **3**: `SRO=0`, `NFC=1`, `CA=2`. (v1 had 3
-  for different families; the count happens to be unchanged but the
-  semantics differ. The CTX entry from earlier v2 drafts is **not**
-  introduced.)
+- Type embedding table size = **3**: `SRO=0`, `NFC=1`, `CA=2`.
 - `forward(sros, nfc, cas)` takes three tensors:
   - `sros`: `[batch, N_sro, d_model]`
   - `nfc`:  `[batch, 1,     d_model]`
@@ -735,18 +706,29 @@ changes:
   `ca_embeddings` at offsets `[N_sro + 1 : N_sro + 1 + N_ca]`. Mean
   pooling for the critic spans **all** tokens (SRO + NFC + CA).
 
-Pre-LN, GELU, no positional embeddings — unchanged.
+Pre-LN, GELU, no positional embeddings.
+
+### Tests (`tests/test_transformer_backbone.py`)
+
+| Test | Verifies |
+|---|---|
+| `test_type_embedding_table_size_3` | `nn.Embedding(3, d_model)` (SRO=0, NFC=1, CA=2) |
+| `test_concat_order_sros_nfc_cas` | First N_sro slots are sro tokens, slot N_sro is nfc, last block is ca |
+| `test_ca_embeddings_sliced_at_correct_offset` | Slice = `[N_sro + 1 : N_sro + 1 + N_ca]` |
+| `test_pooled_includes_sro_and_nfc_tokens` | Pooling spans all tokens (sros + nfc + cas) |
+| `test_gradient_flow_through_sro_tokens` | Backward through any sro token reaches the corresponding per-type projection |
+| `test_gradient_flow_through_nfc_token` | Backward through nfc reaches `projections["building_nfc"]` and the NfcExpression source indices |
 
 ---
 
-## 10. PPO Components & Action Contract
+## 9. PPO Components & Action Contract
 
-### 10.1 CA token order ↔ action order
+### 9.1 CA token order ↔ action order
 
 CA order is owned exclusively by `EntityTokenLayoutBuilder.build()`,
 which receives `action_names[building]` and constructs `segments` so
 that `BuildingTokenLayout.ca_action_names == tuple(action_names[building])`
-by construction (see §7.3).
+by construction (see §6.3).
 
 `AgentTransformerPPO.predict()` returns one scalar per CA token, in the
 order produced by `BuildingTokenLayout.segments`. The wrapper then
@@ -774,9 +756,9 @@ for b in range(len(action_names)):
 ```
 
 The same assertion runs inside `on_topology_change(b)` after the layout
-is rebuilt (see §12.2).
+is rebuilt (see §11.2).
 
-### 10.2 Reused PPO modules (verbatim from `gj/plan-c`)
+### 9.2 PPO modules
 
 - `ActorHead` — MLP per CA embedding; tanh-squashed Gaussian; learnable
   shared `log_std` per CA *type*.
@@ -784,19 +766,19 @@ is rebuilt (see §12.2).
 - `RolloutBuffer` — On-policy buffer with GAE.
 - `compute_ppo_loss` — Clipped surrogate + value loss + entropy bonus.
 
-### 10.3 Action range and clipping
+### 9.3 Action range and clipping
 
 `predict()` returns values in `[-1, 1]`. The wrapper clips to per-agent
 action-space bounds via the existing `_clip_actions`
-(`utils/wrapper_citylearn.py:743-779`).
+(`utils/wrapper_citylearn.py`).
 
 ---
 
-## 11. AgentTransformerPPO (v2)
+## 10. AgentTransformerPPO
 
-### 11.1 `BaseAgent` contract — exact signatures
+### 10.1 `BaseAgent` contract — exact signatures
 
-Copied from `algorithms/agents/base_agent.py:16-84`. Note `terminated` /
+Copied from `algorithms/agents/base_agent.py`. Note `terminated` /
 `truncated` are **scalar booleans** (not lists), `output_dir` is `str`,
 `predict` returns `List[List[float]]`, and `attach_environment` uses
 keyword-only arguments.
@@ -819,7 +801,7 @@ class AgentTransformerPPO(BaseAgent):
         """Build per-building EntityObservationTokenizer / TransformerBackbone /
         ActorHead / CriticHead / RolloutBuffer; store entity_specs; build the
         initial BuildingTokenLayout per building; validate CA-order vs
-        action_names (see §10.1)."""
+        action_names (see §9.1)."""
 
     def predict(
         self,
@@ -844,45 +826,63 @@ class AgentTransformerPPO(BaseAgent):
 
     def on_topology_change(self, building_idx: int) -> None:
         """Triggered by the wrapper after _entity_topology_version increments
-        (excluding the first attach — see §12.1).
+        (excluding the first attach — see §11.1).
         1. If rollout buffer has data → run a PPO update on collected trajectory.
         2. Clear the rollout buffer.
         3. Rebuild the BuildingTokenLayout from new observation_names + action_names.
-        4. Re-run §13.4 rules 1–5 against new entity_specs (coverage,
+        4. Re-run §12.4 rules 1–5 against new entity_specs (coverage,
            uniqueness, NFC sources, pattern compilation, action-field coverage).
-        5. The §10.1 CA-order post-condition is implicit in rule 5."""
+        5. The §9.1 CA-order post-condition is implicit in rule 5."""
 
     def export_artifacts(self, output_dir: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]: ...
     def save_checkpoint(self, output_dir: str, step: int) -> Optional[str]: ...
     def load_checkpoint(self, checkpoint_path: str) -> None: ...
 ```
 
-### 11.2 Per-building structure
+### 10.2 Per-building structure
 
 Each building owns: tokenizer, backbone, actor, critic, rollout buffer,
-optimizer, cached `BuildingTokenLayout`. Same as v1.
+optimizer, cached `BuildingTokenLayout`.
+
+### Tests (`tests/test_agent_transformer_ppo.py`)
+
+| Test | Verifies |
+|---|---|
+| `test_attach_environment_builds_layouts` | One `BuildingTokenLayout` per building, cached |
+| `test_attach_environment_validates_ca_action_order` | Mismatched `action_names` order raises |
+| `test_attach_environment_does_not_treat_first_call_as_topology_change` | No PPO update, no buffer flush |
+| `test_predict_action_count_matches_n_ca` | `len(actions[b]) == n_ca[b]` |
+| `test_predict_returns_list_of_lists_of_float` | Matches `BaseAgent.predict` signature |
+| `test_deterministic_uses_means` | Two deterministic calls → identical actions |
+| `test_stochastic_samples` | Two stochastic calls → different actions (>1e-6) |
+| `test_update_signature_uses_scalar_terminated_truncated` | Calling with `bool` works; calling with `List[bool]` raises a clear TypeError from upstream |
+| `test_update_returns_none` | Matches `BaseAgent.update` |
+| `test_on_topology_change_runs_update_then_flushes_buffer` | Buffer length == 0 after; PPO step counter incremented |
+| `test_on_topology_change_rebuilds_layout` | New layout reflects new observation_names |
+| `test_on_topology_change_validates_input_dim` | Raises if entity_specs dim != tokenizer dim |
+| `test_supports_dynamic_topology_flag` | `AgentTransformerPPO.supports_dynamic_topology is True` |
+| `test_checkpoint_round_trip_same_topology` | Save → load → identical weights |
+| `test_checkpoint_load_rejects_layout_signature_mismatch` | Loading into a different topology raises |
 
 ---
 
-## 12. Lifecycle: Reset, Topology Change, Buffer Flush, PPO
+## 11. Lifecycle: Reset, Topology Change, Buffer Flush, PPO
 
-This section makes the boundaries the reviewer asked for explicit.
-
-### 12.1 First attach (wrapper construction → `set_model`)
+### 11.1 First attach (wrapper construction → `set_model`)
 
 The wrapper attaches the agent in **two stages** in the current code:
 
 1. `Wrapper_CityLearn.__init__` calls `_apply_entity_layout(payload,
-   force_attach=False)` (`utils/wrapper_citylearn.py:306`). At this
+   force_attach=False)` (`utils/wrapper_citylearn.py`). At this
    point `self.model is None`, so the inner
    `_attach_model_environment_metadata()` short-circuits
-   (`utils/wrapper_citylearn.py:344-346`). The wrapper has populated
+   (`utils/wrapper_citylearn.py`). The wrapper has populated
    `observation_names`, `observation_space`, `action_space`,
    `action_names`, `encoders`.
 2. `run_experiment.py` later instantiates the agent and calls
    `wrapper.set_model(agent)`, which assigns `self.model = agent` and
    immediately calls `_attach_model_environment_metadata()`
-   (`utils/wrapper_citylearn.py:418-423`). **This is the real first
+   (`utils/wrapper_citylearn.py`). **This is the real first
    `attach_environment(...)` invocation for the agent.**
 
 The Transformer agent therefore implements `attach_environment` so that
@@ -895,7 +895,7 @@ it works in this order:
    buffer / optimizer.
 3. Build layouts: `layouts[b] = layout_builder.build(building_id[b],
    observation_names[b], action_names[b])`.
-4. Run the post-condition assertion in §10.1.
+4. Run the post-condition assertion in §9.1.
 5. Do **not** treat this as a topology change — buffers are empty by
    definition; no PPO update is attempted.
 
@@ -904,78 +904,77 @@ identical `observation_names`/`action_names` (no-op, returns without
 mutation) because the wrapper may re-emit metadata on episode reset
 without a topology change.
 
-### 12.2 Genuine topology change mid-episode
+### 11.2 Genuine topology change mid-episode
 
-Call site: `Wrapper_CityLearn._apply_entity_layout`
-(`utils/wrapper_citylearn.py:309-342`) detects
+Call site: `Wrapper_CityLearn._apply_entity_layout` detects
 `previous_version is not None and self._entity_topology_version != previous_version`.
 
 The wrapper is the **single owner** of the rebuild trigger. The agent
 owns layout reconstruction. Sequence (must run in this order):
 
 1. Wrapper rebuilds `observation_names`, `observation_space`,
-   `action_space`, `action_names`, `encoders` (already happens at
-   `utils/wrapper_citylearn.py:317-326`).
-2. Wrapper calls `_attach_model_environment_metadata()` so the agent
-   sees the **new** `observation_names`/`action_names`/`entity_specs`
-   *before* it rebuilds layouts. (This replaces the existing call at
-   `utils/wrapper_citylearn.py:339-340`, which already runs in this
-   slot.)
-3. Wrapper calls
-   `TransformerObservationCoordinator.handle_topology_change(self)`,
-   which loops `for b in range(len(self.observation_names))` and calls
-   `agent.on_topology_change(b)`.
-4. Inside `on_topology_change(b)`:
+   `action_space`, `action_names`, `encoders`, `_action_bounds_cache`.
+2. Wrapper calls `_attach_model_environment_metadata()`, which invokes
+   `agent.attach_environment(...)` with the **new**
+   `observation_names`/`action_names`/`entity_specs`.
+3. `agent.attach_environment` compares per-building
+   `(observation_names, action_names)` against its cached tuples and,
+   for each building whose tuple changed, calls
+   `agent._handle_topology_change(b)`:
    a. If `rollout_buffer[b]` has data → run a single PPO update on the
       collected trajectory using the **previous** layout (cached on the
-      agent until step 4c). PPO is on-policy and the data was collected
+      agent until step c). PPO is on-policy and the data was collected
       under the old policy/topology, so this is the only sound moment
       to flush.
    b. Clear `rollout_buffer[b]`.
    c. Rebuild `layouts[b] = layout_builder.build(building_id[b],
       observation_names[b], action_names[b])`. Re-pre-register
       tokenizer index buffers.
-   d. Re-run §13.4 rules 1–5 against the new `entity_specs` (coverage,
+   d. Re-run §12.4 rules 1–5 against the new `entity_specs` (coverage,
       uniqueness, NFC sources, pattern compilation already cached, action-
       field coverage). Raise on any mismatch.
-   e. Re-run the §10.1 post-condition assertion.
-
-`attach_environment` does **not** rebuild layouts on its own when called
-during a topology change — the coordinator path above is the single
-entry point for layout rebuilds. This avoids the double-build that the
-reviewer flagged.
+   e. Re-run the §9.1 post-condition assertion.
 
 > Edge case: a topology change in the middle of an unfinished
 > `update_step` window is handled here (the buffer is force-flushed). The
 > next regularly-scheduled `update_step` will then operate on a fresh
 > buffer.
 
-### 12.3 No-op steps
+### 11.3 No-op steps
 
-When `_apply_entity_layout` runs but `topology_version` did not change, the
-coordinator does **nothing**. The agent does **not** rebuild layouts,
-buffers, or anything else.
+When `_apply_entity_layout` runs but `topology_version` did not change,
+`agent.attach_environment` observes identical per-building tuples and
+returns without touching any layout, buffer, or weight.
 
-### 12.4 Dynamic-topology guardrail (generalised)
+### 11.4 Dynamic-topology guardrail
 
-The current MADDPG-specific raise (`utils/wrapper_citylearn.py:333-338` and
-`utils/config_schema.py:352-356`) is replaced by a single, generic rule:
+A single rule enforced at both config-load time and wrapper runtime:
 
 - Each agent class declares `supports_dynamic_topology: ClassVar[bool]`
-  (default `False`). `MADDPG` keeps `False`; `RuleBasedPolicy` is `True`
-  (it already works dynamically); `AgentTransformerPPO` is `True`.
+  (default `False`). `MADDPG` keeps `False`; `RuleBasedPolicy` is `True`;
+  `AgentTransformerPPO` is `True`.
 - `utils/config_schema.py` reads the registry at validation time and
-  raises if `simulator.topology_mode == "dynamic"` and the chosen
+  raises if `simulator.topology_mode == "dynamic"` and any stage's
   algorithm class has `supports_dynamic_topology is False`. The error
   message keeps the existing wording for MADDPG to preserve test output.
 - `utils/wrapper_citylearn.py` keeps a runtime double-check (defence in
-  depth) but uses the same flag rather than a hard-coded `MADDPG` literal.
+  depth) using the same flag.
+
+### Tests (`tests/test_agent_transformer_ppo_wrapper_integration.py`)
+
+| Test | Verifies |
+|---|---|
+| `test_topology_version_increment_triggers_rebuild` | Mock env where `meta.topology_version` flips → encoders + layouts + agent rebuilds happen exactly once |
+| `test_topology_unchanged_does_not_rebuild` | Repeated steps with same `topology_version` → no rebuilds |
+| `test_action_conversion_uses_entity_adapter_tables_only` | Wrapper outputs `{"tables": {"building": ndarray, "charger": ndarray}}`; no `"map"` key |
+| `test_dynamic_guardrail_uses_supports_dynamic_topology_flag` | Setting flag to False on a dummy agent triggers the existing schema/runtime error; True does not |
+| `test_maddpg_dynamic_error_message_unchanged` | The exact MADDPG error string remains so existing tests continue to pass |
 
 ---
 
-## 13. Configuration
+## 12. Configuration
 
-### 13.1 Tokenizer config
+### 12.1 Tokenizer config
 
 `configs/tokenizers/entity_default.json`
 
@@ -1239,13 +1238,13 @@ Per-asset SRO and CA token counts vary at runtime with topology.
 The `nfc` block declares the **single** NFC token. `expression.op`
 must be one of: `subtract`. `left.feature` and `right.feature` must
 exist in the `entity_table`. The tokenizer collapses these two source
-features into a scalar at forward time (§8.3) — the source features
-do not appear in any SRO group (§7.3 step 2).
+features into a scalar at forward time (§7.3) — the source features
+do not appear in any SRO group (§6.3 step 2).
 
 To change the NFC definition (e.g. add a third term, or use a
 different expression), modify this block — no code change required.
 
-### 13.2 Algorithm template (full repo-valid shape)
+### 12.2 Algorithm template (full repo-valid shape)
 
 `configs/templates/transformer_ppo_entity_dynamic.yaml`
 
@@ -1335,28 +1334,26 @@ topology:
   action_dimensions: null
   action_space: null
 
-algorithm:
-  name: "AgentTransformerPPO"
-  tokenizer_config_path: configs/tokenizers/entity_default.json
-  transformer:
-    d_model: 64
-    nhead: 4
-    num_layers: 2
-    dim_feedforward: 128
-    dropout: 0.1
-  hyperparameters:
-    learning_rate: 3.0e-4
-    gamma: 0.99
-    gae_lambda: 0.95
-    clip_eps: 0.2
-    ppo_epochs: 4
-    minibatch_size: 64
-    entropy_coeff: 0.01
-    value_coeff: 0.5
-    max_grad_norm: 0.5
-  networks: null
-  replay_buffer: null
-  exploration: null
+pipeline:
+  - algorithm: "AgentTransformerPPO"
+    count: 1
+    tokenizer_config_path: configs/tokenizers/entity_default.json
+    transformer:
+      d_model: 64
+      nhead: 4
+      num_layers: 2
+      dim_feedforward: 128
+      dropout: 0.1
+    hyperparameters:
+      learning_rate: 3.0e-4
+      gamma: 0.99
+      gae_lambda: 0.95
+      clip_eps: 0.2
+      ppo_epochs: 4
+      minibatch_size: 64
+      entropy_coeff: 0.01
+      value_coeff: 0.5
+      max_grad_norm: 0.5
 
 execution: null
 ```
@@ -1365,19 +1362,20 @@ This template mirrors the field set of
 `configs/templates/rule_based_entity_dynamic_assets_only_local.yaml` so it
 will pass `validate_config(...)` without further plumbing.
 
-### 13.3 Hyperparameter naming (canonical)
+### 12.3 Hyperparameter naming (canonical)
 
 The single canonical name for the optimizer learning rate is
-**`learning_rate`** (matching v1 spec §9 and the YAML above). Internally the
-agent may alias `self.lr = self.config["algorithm"]["hyperparameters"]["learning_rate"]`,
+**`learning_rate`** (matching the YAML above). Internally the agent may
+alias `self._lr = self.config["algorithm"]["hyperparameters"]["learning_rate"]`,
 but no schema, config or docstring uses `lr` as the canonical key.
 
-### 13.4 Tokenizer JSON validation
+### 12.4 Tokenizer JSON validation
 
-`utils/config_schema.py` is extended with `EntityTokenizerConfig` (Pydantic).
-After successfully loading a YAML config that names
-`AgentTransformerPPO`, `validate_config(...)` opens the file at
-`algorithm.tokenizer_config_path`, parses it as JSON, constructs
+`utils/config_schema.py` extends `PipelineStageConfig` with
+`TransformerPPOStageConfig`. After successfully loading a YAML config,
+`validate_config(...)` walks `project.pipeline` and, for each stage of
+type `TransformerPPOStageConfig`, opens the file at
+`tokenizer_config_path`, parses it as JSON, constructs
 `EntityTokenizerConfig.model_validate(...)`, and then enforces the
 following **five hard-fail rules** against a real entity-payload sample
 (loaded from the configured dataset, or from
@@ -1406,7 +1404,7 @@ hasn't been instantiated yet):
    and the regex error message.
 5. **Action-field coverage.** Every `ca_types[*].action_field` must
    appear in `action_names[building]` for every building reported by
-   the dataset. Missing → `ValueError` (this is the existing §10.1
+   the dataset. Missing → `ValueError` (this is the existing §9.1
    post-condition, generalised).
 
 These same rules also run at runtime inside `attach_environment` and
@@ -1418,9 +1416,9 @@ Validation is performed in a single authoritative place
 (`validate_config`) — no caller may instantiate
 `AgentTransformerPPO` with a malformed tokenizer config.
 
-### 13.5 Schema additions summary
+### 12.5 Schema additions summary
 
-- `EntityTokenizerConfig` — fields per §13.1:
+- `EntityTokenizerConfig` — fields per §12.1:
   - `type_embeddings: Mapping[Literal["SRO","NFC","CA"], int]` (must equal
     `{"SRO": 0, "NFC": 1, "CA": 2}`).
   - `excluded_features: ExcludedFeaturesConfig` (with `patterns: List[str]`).
@@ -1438,23 +1436,40 @@ Validation is performed in a single authoritative place
     `unmatched_features`, `ambiguous_pattern_match`,
     `input_dim_mismatch`. All must be `"fail"` (no soft modes today —
     reserved for the future).
-- `TransformerConfig` — `d_model`, `nhead`, `num_layers`, `dim_feedforward`,
-  `dropout` (positive ints / unit-interval floats).
+- `TransformerPPOTransformerConfig` — `d_model`, `nhead`, `num_layers`,
+  `dim_feedforward`, `dropout` (positive ints / unit-interval floats).
 - `TransformerPPOHyperparameters` — `learning_rate`, `gamma`, `gae_lambda`,
   `clip_eps`, `ppo_epochs`, `minibatch_size`, `entropy_coeff`,
   `value_coeff`, `max_grad_norm`.
-- `TransformerPPOAlgorithmConfig` — `name: Literal["AgentTransformerPPO"]`,
-  `tokenizer_config_path: str`, `transformer: TransformerConfig`,
+- `TransformerPPOStageConfig` — pipeline-stage variant:
+  `algorithm: Literal["AgentTransformerPPO"]`, `count: int`, `frozen: bool`,
+  `tokenizer_config_path: str`, `transformer: TransformerPPOTransformerConfig`,
   `hyperparameters: TransformerPPOHyperparameters`. Added to
-  `ProjectConfig.algorithm` discriminated union.
+  `PipelineStageConfig` discriminated union.
 - Generic dynamic-topology guardrail (replaces MADDPG-specific check, see
-  §12.4).
+  §11.4).
+
+### Tests (`tests/test_entity_tokenizer_config_schema.py`)
+
+| Test | Verifies |
+|---|---|
+| `test_valid_json_loads` | The shipped `entity_default.json` validates against `EntityTokenizerConfig` and passes all 5 hard-fail rules on the sample payload |
+| `test_missing_ca_type_raises` | Removing `ca_types.charger` fails Pydantic validation |
+| `test_unknown_field_raises` | Extra unknown field at any level fails (strict mode) |
+| `test_validate_config_loads_tokenizer_json` | Top-level `validate_config(...)` invokes the JSON loader and reports the JSON path on failure |
+| `test_rule1_unmatched_feature_fails` | Add a fake feature `district__some_new_thing` to the sample payload → `ValueError` listing it |
+| `test_rule2_ambiguous_pattern_fails` | Two SRO types with overlapping patterns → `ValueError` listing the colliding feature and types |
+| `test_rule3_missing_nfc_source_fails` | Tokenizer references `nfc.expression.left.feature = "does_not_exist"` → `ValueError` |
+| `test_rule4_bad_regex_fails` | A `feature_patterns` entry like `"^[unclosed"` → `ValueError` reporting the JSON path and regex error |
+| `test_rule5_missing_action_field_fails` | Set `ca_types.charger.action_field = "no_such_action"` → `ValueError` |
+| `test_excluded_feature_pattern_removes_topology_version` | After validation, `district__topology_version` is in `excluded_feature_names` for every building |
+| `test_excluded_feature_cannot_match_an_sro_type` | Same feature in both `excluded_features.patterns` and an SRO `feature_patterns` → rule 2 conflict |
 
 ---
 
-## 14. Export & Checkpoint Contract (dynamic topology)
+## 13. Export & Checkpoint Contract (dynamic topology)
 
-### 14.1 ONNX export
+### 13.1 ONNX export
 
 Per-building, per call to `export_artifacts(output_dir, context=...)`. For
 each building `b`:
@@ -1475,17 +1490,17 @@ each building `b`:
   valid if encoded length changes inside the same topology, which it
   doesn’t today but is cheap to guard against).
 
-### 14.2 Manifest entries
+### 13.2 Manifest entries
 
 `export_artifacts` MUST return the canonical artifact payload required
-by `utils/artifact_manifest.py:69-84` and validated by
-`utils/bundle_validator.py:108-172`. The required keys are `format`
+by `utils/artifact_manifest.py` and validated by
+`utils/bundle_validator.py`. The required keys are `format`
 (top-level) and `artifacts` (a non-empty list, one entry per building,
 each with `agent_index: int >= 0`, `path: str` pointing to a file that
 exists under `output_dir`, and a JSON-serialisable `config` object).
 For ONNX artifacts the file MUST end in `.onnx`. The number of entries
 in `artifacts` MUST equal `topology.num_agents` (set by
-`run_experiment.py:691-697` from the wrapper just before
+`run_experiment.py` from the wrapper just before
 `export_artifacts` runs).
 
 Returned shape:
@@ -1551,12 +1566,12 @@ The `format` and `artifacts` fields are mandatory (validated by
 `bundle_validator`). The remaining fields (`tokenizer_config_path`,
 `supports_dynamic_topology`, `agent_models`) are supplemental metadata
 used by debugging and tooling and are passed through verbatim by
-`build_manifest` (`utils/artifact_manifest.py:41`).
+`build_manifest` (`utils/artifact_manifest.py`).
 
 We export **only the topology version current at export time**; no
 cross-topology weight portability is required for production.
 
-### 14.3 Checkpoints
+### 13.3 Checkpoints
 
 - File: `<output_dir>/checkpoints/transformer_ppo_step<step>.pt`.
 - Payload (`torch.save`):
@@ -1582,180 +1597,7 @@ cross-topology weight portability is required for production.
   `layout_signature` differs from the saved one, with an error pointing to
   the field that disagrees. Cross-topology resumption is **not** supported.
 
----
-
-## 15. File Structure & Work Packages
-
-### 15.1 Files
-
-(See §2 for the full delta. Summary view here.)
-
-```
-algorithms/
-├── agents/
-│   ├── transformer_ppo_agent.py                 # PORT from gj/plan-c, surgical edits
-│   └── transformer_ppo/
-│       ├── __init__.py                          # PORT
-│       ├── state_helper.py                      # PORT, drop marker registry
-│       ├── update_helper.py                     # PORT verbatim
-│       └── export_helper.py                     # PORT, drive shapes from layout
-├── utils/
-│   ├── entity_token_layout.py                   # NEW
-│   ├── entity_observation_tokenizer.py          # NEW
-│   ├── transformer_backbone.py                  # PORT, extend type embedding to 4
-│   └── ppo_components.py                        # PORT verbatim
-
-configs/
-├── tokenizers/
-│   └── entity_default.json                      # NEW
-└── templates/
-    └── transformer_ppo_entity_dynamic.yaml      # NEW
-
-utils/
-├── wrapper_citylearn.py                         # MODIFY (coordinator hook, generic guardrail)
-├── wrapper_transformer/
-│   ├── __init__.py                              # NEW
-│   └── transformer_observation_coordinator.py   # NEW
-└── config_schema.py                             # MODIFY (new models, JSON validation, generic guardrail)
-
-algorithms/registry.py                           # MODIFY (register AgentTransformerPPO)
-
-tests/
-├── test_entity_token_layout.py                  # NEW
-├── test_entity_observation_tokenizer.py         # NEW
-├── test_transformer_backbone.py                 # PORT + extend
-├── test_ppo_components.py                       # PORT
-├── test_agent_transformer_ppo_entity.py         # NEW
-├── test_wrapper_transformer_entity.py           # NEW
-└── test_e2e_transformer_ppo_entity_dynamic.py   # NEW
-
-docs/
-└── transformer_ppo_spec.md                     # this document
-```
-
-### 15.2 Work packages
-
-| WP | Component | Depends on | Deliverables |
-|----|---|---|---|
-| WP0 | Bring sources from `gj/plan-c` | — | Backbone, PPO components, helpers (see §2.2) |
-| WP1 | `EntityTokenLayoutBuilder` | — | `entity_token_layout.py` + tests |
-| WP2 | Tokenizer config + Pydantic schema + JSON validation | — | `entity_default.json`, `EntityTokenizerConfig`, validator hook |
-| WP3 | `EntityObservationTokenizer` | WP1, WP2 | `entity_observation_tokenizer.py` + tests |
-| WP4 | TransformerBackbone update (3-entry type embedding, new forward signature `(sros, nfc, cas)`) | WP0 | extended backbone + tests |
-| WP5 | PPO components verification | WP0 | re-run ported tests |
-| WP6 | `TransformerObservationCoordinator` | WP1 | coordinator + tests |
-| WP7 | Wrapper hooks + generic guardrail | WP6 | wrapper diff + integration tests |
-| WP8 | `AgentTransformerPPO` (CA-order check, attach lifecycle) | WP3, WP4, WP5, WP7 | agent + helpers + tests |
-| WP9 | Algorithm template, registry, schema additions | WP2, WP8 | yaml, registry, schema |
-| WP10 | E2E validation on `citylearn_three_phase_dynamic_assets_only_demo` | All | smoke test producing KPIs and ONNX |
-
-Parallelizable: WP0, WP1, WP2.
-
----
-
-## 16. Test Plan
-
-### 16.1 `EntityTokenLayoutBuilder` (`tests/test_entity_token_layout.py`)
-
-| Test | Verifies |
-|---|---|
-| `test_classifies_district_time_to_sro_singleton` | `district__hour` → `(sro, "district_time", building_id)` |
-| `test_classifies_district_pricing_current_separately_from_forecast` | `district__electricity_pricing` → `district_pricing_current`; `district__electricity_pricing_predicted_2` → `district_pricing_forecast` |
-| `test_classifies_district_carbon_separately_from_pricing` | `district__carbon_intensity` → `district_carbon`, not `district_pricing_*` |
-| `test_classifies_building_storage_state_to_sro` | `electrical_storage_soc`, `electrical_storage_soc_ratio` → `(sro, "building_storage_state")` |
-| `test_classifies_per_asset_pv_to_sro` | `pv::Building_1/pv::generation_power_kw` → `(sro, "pv", "Building_1/pv")` |
-| `test_classifies_per_asset_ev_connected_to_sro` | `charger::B/c::connected_ev::soc` → `(sro, "ev_connected", "B/c")` |
-| `test_classifies_per_asset_ev_incoming_to_sro` | `charger::B/c::incoming_ev::soc` → `(sro, "ev_incoming", "B/c")` |
-| `test_classifies_storage_prefix_to_ca` | `storage::Building_1/electrical_storage::soc` → `(ca, "storage", "Building_1/electrical_storage")` |
-| `test_classifies_charger_prefix_to_ca` | `charger::B/c::connected_state` → `(ca, "charger", "B/c")` |
-| `test_nfc_segment_has_two_source_indices_and_subtract_op` | NFC segment has `feature_indices=(idx_nsl, idx_solar)`; `derived.op == "subtract"` |
-| `test_nfc_source_features_not_in_any_sro_group` | `non_shiftable_load` and `solar_generation` do not appear in any SRO segment’s `feature_names` |
-| `test_excluded_features_dropped_before_classification` | `district__topology_version` and legacy charger aliases appear in `excluded_feature_names` and not in any segment |
-| `test_unmatched_feature_raises` | Inject a never-seen feature `district__some_new_feature` → `ValueError` listing the feature and table |
-| `test_ambiguous_pattern_raises` | Two SRO types claim the same feature → `ValueError` |
-| `test_sro_segment_order_follows_config_declaration` | `district_time` segment appears before `district_weather_current`, etc. |
-| `test_per_asset_sro_segments_sorted_by_instance_id` | Two PVs → segments in lexicographic order of `instance_id` |
-| `test_segment_overall_order` | `[sros…, nfc, cas…sorted_by_action_position]` |
-| `test_topology_changed_when_names_differ` | Adding a new charger → True |
-| `test_topology_unchanged_for_identical_names` | False |
-| `test_layout_is_cached` | Repeated `build()` returns the same instance |
-| `test_no_external_imports` | Module imports only stdlib + typing + re |
-| `test_uses_real_sample_payload` | Build layout from `configs/tokenizers/fixtures/entity_obs_sample.json` (passed through the adapter) succeeds for every building, with all 46 district + 38 building features accounted for |
-| `test_coverage_accounting_matches_spec` | Per-table feature counts in §13.1 coverage table are reproduced exactly |
-
-### 16.2 `EntityObservationTokenizer` (`tests/test_entity_observation_tokenizer.py`)
-
-| Test | Verifies |
-|---|---|
-| `test_forward_shapes_baseline` | sro_tokens=[1,N_sro,d], nfc_token=[1,1,d], ca_tokens=[1,N_ca,d] for the sample payload |
-| `test_forward_shapes_extra_charger` | ca_tokens=[1,2,d] when a second charger is present |
-| `test_projection_is_per_type_no_new_params_on_topology_grow` | Adding chargers / PVs does NOT add new parameters |
-| `test_index_select_handles_non_contiguous_sro_segment` | Mock encoded vector with sentinel values; verify `district_weather_forecast` slice gathers correct interleaved positions |
-| `test_nfc_token_value_equals_subtract_op` | Mock `non_shiftable_load=5.0`, `solar_generation=2.0` → NFC scalar = 3.0 (pre-projection) |
-| `test_nfc_input_dim_is_one` | `projections["building_nfc"].in_features == 1` |
-| `test_input_dim_mismatch_raises` | type_input_dims != entity_specs dim → clear ValueError naming both sides and the affected type |
-| `test_dtype_and_device_propagation` | Input cuda → output cuda; input float32 → output float32 |
-
-### 16.3 TransformerBackbone update (`tests/test_transformer_backbone.py`)
-
-| Test | Verifies |
-|---|---|
-| `test_type_embedding_table_size_3` | `nn.Embedding(3, d_model)` (SRO=0, NFC=1, CA=2) |
-| `test_concat_order_sros_nfc_cas` | First N_sro slots are sro tokens, slot N_sro is nfc, last block is ca |
-| `test_ca_embeddings_sliced_at_correct_offset` | Slice = `[N_sro + 1 : N_sro + 1 + N_ca]` |
-| `test_pooled_includes_sro_and_nfc_tokens` | Pooling spans all tokens (sros + nfc + cas) |
-| `test_gradient_flow_through_sro_tokens` | Backward through any sro token reaches the corresponding per-type projection |
-| `test_gradient_flow_through_nfc_token` | Backward through nfc reaches `projections["building_nfc"]` and the NfcExpression source indices |
-
-### 16.4 `AgentTransformerPPO` (`tests/test_agent_transformer_ppo_entity.py`)
-
-| Test | Verifies |
-|---|---|
-| `test_attach_environment_builds_layouts` | One `BuildingTokenLayout` per building, cached |
-| `test_attach_environment_validates_ca_action_order` | Mismatched `action_names` order raises |
-| `test_attach_environment_does_not_treat_first_call_as_topology_change` | No PPO update, no buffer flush |
-| `test_predict_action_count_matches_n_ca` | `len(actions[b]) == n_ca[b]` |
-| `test_predict_returns_list_of_lists_of_float` | Matches `BaseAgent.predict` signature |
-| `test_deterministic_uses_means` | Two deterministic calls → identical actions |
-| `test_stochastic_samples` | Two stochastic calls → different actions (>1e-6) |
-| `test_update_signature_uses_scalar_terminated_truncated` | Calling with `bool` works; calling with `List[bool]` raises a clear TypeError from upstream |
-| `test_update_returns_none` | Matches `BaseAgent.update` |
-| `test_on_topology_change_runs_update_then_flushes_buffer` | Buffer length == 0 after; PPO step counter incremented |
-| `test_on_topology_change_rebuilds_layout` | New layout reflects new observation_names |
-| `test_on_topology_change_validates_input_dim` | Raises if entity_specs dim != tokenizer dim |
-| `test_supports_dynamic_topology_flag` | `AgentTransformerPPO.supports_dynamic_topology is True` |
-| `test_checkpoint_round_trip_same_topology` | Save → load → identical weights |
-| `test_checkpoint_load_rejects_layout_signature_mismatch` | Loading into a different topology raises |
-
-### 16.5 Wrapper integration (`tests/test_wrapper_transformer_entity.py`)
-
-| Test | Verifies |
-|---|---|
-| `test_coordinator_initialised_only_for_transformer_agent` | `RuleBasedPolicy` doesn't trigger coordinator hooks |
-| `test_first_attach_does_not_trigger_topology_change` | `agent.on_topology_change` not called on initial reset |
-| `test_topology_version_increment_triggers_rebuild` | Mock env where `meta.topology_version` flips → encoders + layouts + agent rebuilds happen exactly once |
-| `test_topology_unchanged_does_not_rebuild` | Repeated steps with same `topology_version` → no rebuilds |
-| `test_action_conversion_uses_entity_adapter_tables_only` | Wrapper outputs `{"tables": {"building": ndarray, "charger": ndarray}}`; no `"map"` key |
-| `test_dynamic_guardrail_uses_supports_dynamic_topology_flag` | Setting flag to False on a dummy agent triggers the existing schema/runtime error; True does not |
-| `test_maddpg_dynamic_error_message_unchanged` | The exact MADDPG error string remains so existing tests continue to pass |
-
-### 16.6 Tokenizer JSON validation (`tests/test_entity_tokenizer_config_schema.py`)
-
-| Test | Verifies |
-|---|---|
-| `test_valid_json_loads` | The shipped `entity_default.json` validates against `EntityTokenizerConfig` and passes all 5 hard-fail rules on the sample payload |
-| `test_missing_ca_type_raises` | Removing `ca_types.charger` fails Pydantic validation |
-| `test_unknown_field_raises` | Extra unknown field at any level fails (strict mode) |
-| `test_validate_config_loads_tokenizer_json` | Top-level `validate_config(...)` invokes the JSON loader and reports the JSON path on failure |
-| `test_rule1_unmatched_feature_fails` | Add a fake feature `district__some_new_thing` to the sample payload → `ValueError` listing it |
-| `test_rule2_ambiguous_pattern_fails` | Two SRO types with overlapping patterns → `ValueError` listing the colliding feature and types |
-| `test_rule3_missing_nfc_source_fails` | Tokenizer references `nfc.expression.left.feature = "does_not_exist"` → `ValueError` |
-| `test_rule4_bad_regex_fails` | A `feature_patterns` entry like `"^[unclosed"` → `ValueError` reporting the JSON path and regex error |
-| `test_rule5_missing_action_field_fails` | Set `ca_types.charger.action_field = "no_such_action"` → `ValueError` |
-| `test_excluded_feature_pattern_removes_topology_version` | After validation, `district__topology_version` is in `excluded_feature_names` for every building |
-| `test_excluded_feature_cannot_match_an_sro_type` | Same feature in both `excluded_features.patterns` and an SRO `feature_patterns` → rule 2 conflict |
-
-### 16.7 End-to-end (`tests/test_e2e_transformer_ppo_entity_dynamic.py`)
+### Tests (`tests/e2e/test_e2e_transformer_ppo_entity_dynamic.py`)
 
 Run on `citylearn_three_phase_dynamic_assets_only_demo` for a small horizon.
 
@@ -1765,36 +1607,35 @@ Run on `citylearn_three_phase_dynamic_assets_only_demo` for a small horizon.
 | `test_actions_in_valid_range` | All actions in `[-1, 1]`, no NaN |
 | `test_topology_changes_observed_during_run` | At least one `topology_version` increment in 200 steps (the assets-only demo guarantees this) |
 | `test_kpi_files_generated` | `runs/jobs/<id>/results/{result,summary}.json` exist |
-| `test_artifact_manifest_includes_onnx_per_building` | `artifact_manifest.json` lists per-building ONNX with the naming from §14.2 |
+| `test_artifact_manifest_includes_onnx_per_building` | `artifact_manifest.json` lists per-building ONNX with the naming from §13.2 |
 | `test_buffer_flush_on_topology_change_does_not_crash` | The PPO update triggered by topology change runs and the agent continues training |
 
 ---
-
-## 17. Decisions Log
+## 14. Decisions Log
 
 | # | Question | Decision |
 |---|---|---|
 | 1 | Token boundary signal | Per-feature origin prefixes emitted by `EntityContractAdapter`, classified once per topology by `EntityTokenLayoutBuilder`. No marker values in tensor. |
 | 2 | Topology-change detection | `meta.topology_version` increment, exclusively. No asset/feature counting. |
-| 3 | Per-building vs centralized | Per-building, like v1. |
-| 4 | Action payload | `{"tables": {"building": ndarray, "charger": ndarray}}` only. **No `"map"` field**, matching the current adapter (`utils/entity_adapter.py:548-552`). |
+| 3 | Per-building vs centralized | Per-building. |
+| 4 | Action payload | `{"tables": {"building": ndarray, "charger": ndarray}}` only. **No `"map"` field**, matching the current adapter (`utils/entity_adapter.py`). |
 | 5 | CA token order | Sorted by position in `action_names[building]`, validated at `attach_environment` and `on_topology_change`. |
 | 6 | Graph structure usage | Edges consumed by the wrapper for slicing only. The Transformer treats the result as a set of typed tokens. |
 | 7 | EV / PV handling | Per-asset SRO tokens. EV split into `ev_connected` and `ev_incoming` (matching `connected_ev` / `incoming_ev` adapter labels). PV is its own SRO type. |
-| 8 | RL algorithm | PPO, as in v1. Rollout buffer, GAE, clipped surrogate, K epochs. |
+| 8 | RL algorithm | PPO. Rollout buffer, GAE, clipped surrogate, K epochs. |
 | 9 | Encoder rebuilds | `set_encoders()` is called every `_apply_entity_layout`; cheap (placeholder `NoNormalization`). Agent layout rebuilds are gated on `topology_version` change. |
 | 10 | Type embeddings | 3 families: SRO, NFC, CA. CTX from earlier drafts collapsed into SRO with per-type projections distinguishing semantic groups. |
 | 21 | NFC scope | Strict: NFC = single scalar per building, value of `non_shiftable_load - solar_generation` computed by `NfcExpression`. Other building-table features become singleton SRO types (`building_storage_state`, `building_charging_*`, `building_energy_*`, `building_meta`). |
 | 22 | SRO grouping | Driven by `feature_patterns` (regex) in tokenizer JSON. District split into 10 semantic SROs (time, weather current/forecast, carbon, pricing current/forecast, community energy/headroom/history, meta). Pricing and carbon are separate. Current and forecast are separate. |
 | 23 | Feature exclusion | `excluded_features.patterns` in tokenizer JSON. Excludes `topology_version` (redundant with `meta`) and legacy charger aliases (redundant with per-charger CA tokens). Adding/removing features is config-only. |
-| 24 | Validation rules | Five hard-fail rules in §13.4 enforced both at config-validation time and at runtime on every topology change. No silent dropping of features. |
-| 11 | Reuse policy | Backbone, PPO components, helpers ported from `gj/plan-c@3e9a673`. Marker-based modules replaced. |
+| 24 | Validation rules | Five hard-fail rules in §12.4 enforced both at config-validation time and at runtime on every topology change. No silent dropping of features. |
+| 11 | Reuse policy | Backbone, PPO components, actor/critic heads were ported from an earlier internal branch (`gj/plan-c@3e9a673`) as the historical origin. Marker-based modules were replaced with the entity-aware equivalents. |
 | 12 | Cross-topology checkpoints/exports | Not supported. Checkpoint loader rejects layout-signature mismatch. ONNX file name encodes `topology_version`. |
 | 13 | Dynamic-topology guardrail | Replaced by generic `agent.supports_dynamic_topology` flag, enforced both in `validate_config` and at runtime. MADDPG error message preserved. |
 | 14 | Tokenizer input dims | Read from `entity_specs` at attach time; tokenizer config’s `input_dim_fallback` exists only for inference. |
 | 15 | Tokenizer JSON validation | Performed inside `validate_config(...)` after YAML validation succeeds. |
 | 16 | Hyperparameter naming | `learning_rate` is canonical. `lr` is never used as a config key. |
-| 17 | `terminated`/`truncated` types | Scalar `bool`, matching `BaseAgent.update` (`algorithms/agents/base_agent.py:33`). |
-| 18 | `attach_environment` arguments | Keyword-only, matching `BaseAgent.attach_environment` (`algorithms/agents/base_agent.py:58-65`). |
+| 17 | `terminated`/`truncated` types | Scalar `bool`, matching `BaseAgent.update` (`algorithms/agents/base_agent.py`). |
+| 18 | `attach_environment` arguments | Keyword-only, matching `BaseAgent.attach_environment` (`algorithms/agents/base_agent.py`). |
 | 19 | Encoder dimension expansion | Not supported in v2; encoded length equals raw `observation_names` length (current entity-mode behaviour). No `encoded_index_map`. |
 | 20 | Portability | `EntityTokenLayoutBuilder` stays pure-Python; `EntityObservationTokenizer` (torch) lives only in training repo. |

--- a/scripts/dump_entity_obs_sample.py
+++ b/scripts/dump_entity_obs_sample.py
@@ -4,7 +4,7 @@ The fixture ``configs/tokenizers/fixtures/entity_obs_sample.json`` is a
 JSON snapshot of the simulator's entity schema (per-table feature names
 and row ids, plus edge index pairs). It is loaded by
 ``utils.entity_tokenizer_schema._load_default_sample()`` and used by the
-5 hard-fail tokenizer validation rules (see docs/specv2.md §13.4).
+5 hard-fail tokenizer validation rules (see docs/transformer_ppo_spec.md §13.4).
 
 Regenerate whenever the simulator schema changes (feature added/removed,
 new asset type, adapter emission order changed).

--- a/scripts/dump_entity_obs_sample.py
+++ b/scripts/dump_entity_obs_sample.py
@@ -1,0 +1,163 @@
+"""Regenerate the tokenizer validation fixture from a live simulator.
+
+The fixture ``configs/tokenizers/fixtures/entity_obs_sample.json`` is a
+JSON snapshot of the simulator's entity schema (per-table feature names
+and row ids, plus edge index pairs). It is loaded by
+``utils.entity_tokenizer_schema._load_default_sample()`` and used by the
+5 hard-fail tokenizer validation rules (see docs/specv2.md §13.4).
+
+Regenerate whenever the simulator schema changes (feature added/removed,
+new asset type, adapter emission order changed).
+
+Usage:
+
+    python scripts/dump_entity_obs_sample.py \\
+        --config configs/templates/dynamic/rule_based_entity_dynamic_assets_only_local.yaml \\
+        --output configs/tokenizers/fixtures/entity_obs_sample.json
+
+Any entity-mode config works. Row values are dropped — only ``id`` is
+kept — because validation reads ``tables.<X>.features`` and ``edges``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from citylearn.citylearn import CityLearnEnv
+from reward_function.registry import REWARD_FUNCTION_MAP
+from run_experiment import (
+    _resolve_citylearn_schema_input,
+    _validate_dynamic_entity_schema_input,
+)
+from utils.config_schema import validate_config
+
+
+def _build_env(config: Mapping[str, Any]) -> CityLearnEnv:
+    sim = dict(config["simulator"])
+    interface = str(sim.get("interface", "flat")).strip().lower()
+    topology = str(sim.get("topology_mode", "static")).strip().lower()
+    if interface != "entity":
+        raise ValueError(
+            f"Fixture dump requires simulator.interface='entity'; got {interface!r}"
+        )
+    schema_input = _resolve_citylearn_schema_input(sim["dataset_path"])
+    _validate_dynamic_entity_schema_input(
+        schema_input, interface=interface, topology_mode=topology
+    )
+    reward_cls = REWARD_FUNCTION_MAP.get(sim["reward_function"])
+    if reward_cls is None:
+        raise ValueError(f"Unknown reward function {sim['reward_function']!r}")
+    return CityLearnEnv(
+        schema=schema_input,
+        central_agent=sim["central_agent"],
+        interface=interface,
+        topology_mode=topology,
+        reward_function=reward_cls,
+        offline=True,
+        render_mode="none",
+        export_kpis_on_episode_end=False,
+    )
+
+
+def _edge_pairs(raw_edges: Any) -> list[dict[str, Any]]:
+    """Convert simulator edge output (numpy Nx2 array or list of pairs) to
+    the fixture format: ``[{source_index, target_index, source_id, target_id}, ...]``.
+    """
+    if hasattr(raw_edges, "tolist"):
+        raw_edges = raw_edges.tolist()
+    out: list[dict[str, Any]] = []
+    for pair in raw_edges or []:
+        if isinstance(pair, (list, tuple)) and len(pair) >= 2:
+            src, tgt = int(pair[0]), int(pair[1])
+        elif isinstance(pair, Mapping):
+            src = int(pair.get("source_index", -1))
+            tgt = int(pair.get("target_index", -1))
+        else:
+            continue
+        out.append(
+            {
+                "source_index": src,
+                "target_index": tgt,
+                "source_id": None,
+                "target_id": None,
+            }
+        )
+    return out
+
+
+def _build_fixture(env: CityLearnEnv, payload: Mapping[str, Any]) -> dict[str, Any]:
+    specs = env.entity_specs
+    tables: dict[str, dict[str, Any]] = {}
+    for name, spec in specs["tables"].items():
+        tables[name] = {
+            "features": list(spec.get("features", [])),
+            "rows": [{"id": rid} for rid in spec.get("ids", [])],
+        }
+
+    edges: dict[str, dict[str, Any]] = {}
+    for name, spec in specs.get("edges", {}).items():
+        raw = payload.get("edges", {}).get(name)
+        edges[name] = {
+            "source_table": spec.get("source"),
+            "target_table": spec.get("target"),
+            "edges": _edge_pairs(raw),
+        }
+    # Include mask edges from the payload (present even if not in specs.edges).
+    for name, raw in payload.get("edges", {}).items():
+        if name in edges:
+            continue
+        edges[name] = {
+            "source_table": None,
+            "target_table": None,
+            "edges": _edge_pairs(raw),
+        }
+
+    meta_in = payload.get("meta") or {}
+    return {
+        "tables": tables,
+        "edges": edges,
+        "meta": {
+            "spec_version": meta_in.get("spec_version", "entity_v1"),
+            "topology_version": int(meta_in.get("topology_version", 0)),
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True, help="Path to an entity-mode YAML config")
+    parser.add_argument(
+        "--output",
+        default="configs/tokenizers/fixtures/entity_obs_sample.json",
+        help="Where to write the fixture",
+    )
+    args = parser.parse_args()
+
+    raw_cfg = yaml.safe_load(Path(args.config).read_text())
+    config = validate_config(raw_cfg).to_dict()
+
+    env = _build_env(config)
+    payload, _ = env.reset()
+
+    fixture = _build_fixture(env, payload)
+    Path(args.output).write_text(json.dumps(fixture, indent=2) + "\n")
+
+    summary = ", ".join(
+        f"{name}={len(t['features'])}f/{len(t['rows'])}r"
+        for name, t in fixture["tables"].items()
+    )
+    print(f"wrote {args.output}: {summary}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/_entity_sample_obs_names.py
+++ b/tests/_entity_sample_obs_names.py
@@ -1,0 +1,131 @@
+"""Synthesize per-building observation names from the bundled entity payload
+sample without requiring a CityLearn env.
+
+Mirrors the emission ordering in ``utils/entity_adapter.py`` for the first
+building (``Building_1``) of the bundled tokenizer fixture.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+
+_SAMPLE_PATH = Path("configs/tokenizers/fixtures/entity_obs_sample.json")
+
+
+def _table_features(payload: dict, table: str) -> list[str]:
+    return list(payload["tables"][table]["features"])
+
+
+def _table_row_ids(payload: dict, table: str) -> list[str]:
+    return [row["id"] for row in payload["tables"][table]["rows"]]
+
+
+def _edge_pairs(payload: dict, edge_name: str) -> list[tuple[int, int]]:
+    edges = payload["edges"][edge_name]["edges"]
+    return [(e["source_index"], e["target_index"]) for e in edges]
+
+
+def _edge_targets_for_source(
+    payload: dict, edge_name: str, source_index: int
+) -> list[int]:
+    return [
+        target
+        for src, target in _edge_pairs(payload, edge_name)
+        if src == source_index and target >= 0
+    ]
+
+
+def load_sample_observation_names_for_first_building() -> List[str]:
+    """Return ``observation_names[0]`` for ``Building_1`` of the bundled sample.
+
+    Emission order (matches ``utils/entity_adapter.py``):
+      1. district block (prefixed ``district__``)
+      2. building block (unprefixed)
+      3. per-storage attached to building (prefixed ``storage::<id>::``)
+      4. per-PV attached to building (prefixed ``pv::<id>::``)
+      5. per-charger attached to building, each producing:
+            charger features (``charger::<id>::``)
+            connected_ev features (``charger::<id>::connected_ev::``)
+            incoming_ev features (``charger::<id>::incoming_ev::``)
+      6. operational counters (3 unprefixed)
+      7. RBC alias features OR fallback charger-state features
+      8. ``electric_vehicle_is_flexible``
+    """
+    payload = json.loads(_SAMPLE_PATH.read_text(encoding="utf-8"))
+    district_features = _table_features(payload, "district")
+    building_features = _table_features(payload, "building")
+    storage_features = _table_features(payload, "storage")
+    pv_features = _table_features(payload, "pv")
+    charger_features = _table_features(payload, "charger")
+    ev_features = _table_features(payload, "ev")
+
+    storage_ids = _table_row_ids(payload, "storage")
+    pv_ids = _table_row_ids(payload, "pv")
+    charger_ids = _table_row_ids(payload, "charger")
+
+    building_index = 0  # Building_1
+    storage_targets = _edge_targets_for_source(
+        payload, "building_to_storage", building_index
+    )
+    pv_targets = _edge_targets_for_source(
+        payload, "building_to_pv", building_index
+    )
+    charger_targets = _edge_targets_for_source(
+        payload, "building_to_charger", building_index
+    )
+
+    names: List[str] = []
+    # 1. district
+    for f in district_features:
+        names.append(f"district__{f}")
+    # 2. building
+    for f in building_features:
+        names.append(f)
+    # 3. per-storage
+    for row in storage_targets:
+        sid = storage_ids[row]
+        for f in storage_features:
+            names.append(f"storage::{sid}::{f}")
+    # 4. per-pv
+    for row in pv_targets:
+        pid = pv_ids[row]
+        for f in pv_features:
+            names.append(f"pv::{pid}::{f}")
+    # 5. per-charger (+ connected_ev, + incoming_ev)
+    for row in charger_targets:
+        cid = charger_ids[row]
+        for f in charger_features:
+            names.append(f"charger::{cid}::{f}")
+        for f in ev_features:
+            names.append(f"charger::{cid}::connected_ev::{f}")
+        for f in ev_features:
+            names.append(f"charger::{cid}::incoming_ev::{f}")
+
+    # 6. operational counters
+    names.append("active_chargers_count")
+    names.append("active_storages_count")
+    names.append("active_pvs_count")
+
+    # 7. RBC charger aliases (only when chargers are attached); see
+    #    utils/entity_adapter.py:301-319. Building_1 has chargers attached,
+    #    so the alias branch is taken.
+    if charger_targets:
+        names.append("electric_vehicle_charger_state")
+        names.append("electric_vehicle_soc")
+        names.append("electric_vehicle_required_soc_departure")
+        names.append("electric_vehicle_departure_time")
+    else:
+        names.extend(
+            [
+                "electric_vehicle_charger_state",
+                "electric_vehicle_soc",
+                "electric_vehicle_required_soc_departure",
+                "electric_vehicle_departure_time",
+            ]
+        )
+
+    # 8. flexibility flag
+    names.append("electric_vehicle_is_flexible")
+    return names

--- a/tests/test_entity_tokenizer_config_schema.py
+++ b/tests/test_entity_tokenizer_config_schema.py
@@ -1,0 +1,286 @@
+"""Tests for entity tokenizer JSON schema and the 5 hard-fail validation rules."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schema
+# ---------------------------------------------------------------------------
+
+
+def test_valid_json_loads():
+    from utils.entity_tokenizer_schema import load_entity_tokenizer_config
+
+    cfg = load_entity_tokenizer_config(
+        "configs/tokenizers/entity_default.json"
+    )
+    assert cfg.type_embeddings == {"SRO": 0, "NFC": 1, "CA": 2}
+    assert cfg.nfc.type_name == "building_nfc"
+    assert cfg.nfc.entity_table == "building"
+    assert cfg.nfc.expression.op == "subtract"
+    assert "storage" in cfg.ca_types
+    assert "charger" in cfg.ca_types
+    assert "district_time" in cfg.sro_types
+    assert "pv" in cfg.sro_types
+
+
+def test_missing_ca_type_raises():
+    from utils.entity_tokenizer_schema import EntityTokenizerConfig
+
+    raw = json.loads(
+        Path("configs/tokenizers/entity_default.json").read_text()
+    )
+    raw["ca_types"].pop("charger")
+    with pytest.raises(ValueError, match="charger"):
+        EntityTokenizerConfig.model_validate(raw)
+
+
+def test_unknown_field_raises():
+    from utils.entity_tokenizer_schema import EntityTokenizerConfig
+
+    raw = json.loads(
+        Path("configs/tokenizers/entity_default.json").read_text()
+    )
+    raw["mystery_extra_field"] = 42
+    with pytest.raises(ValueError, match="mystery_extra_field|extra"):
+        EntityTokenizerConfig.model_validate(raw)
+
+
+def test_default_payload_sample_loads_from_repo():
+    from utils.entity_tokenizer_schema import _load_default_sample
+
+    sample = _load_default_sample()
+    # Expected coverage: district has 46 features, building has 38.
+    assert len(sample.feature_names_per_table["district"]) == 46
+    assert len(sample.feature_names_per_table["building"]) == 38
+    assert "district__hour" in sample.feature_names_per_table["district"]
+    assert (
+        "non_shiftable_load" in sample.feature_names_per_table["building"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule 1 — coverage
+# ---------------------------------------------------------------------------
+
+
+def test_rule1_default_config_passes_coverage():
+    from utils.entity_tokenizer_schema import (
+        _load_default_sample,
+        load_entity_tokenizer_config,
+        validate_against_payload,
+    )
+
+    cfg = load_entity_tokenizer_config(
+        "configs/tokenizers/entity_default.json"
+    )
+    sample = _load_default_sample()
+    action_names = [["electrical_storage", "electric_vehicle_storage"]]
+    validate_against_payload(cfg, sample, action_names)  # must not raise
+
+
+def test_rule1_unmatched_feature_fails():
+    from utils.entity_tokenizer_schema import (
+        EntityPayloadSample,
+        load_entity_tokenizer_config,
+        validate_against_payload,
+    )
+
+    cfg = load_entity_tokenizer_config(
+        "configs/tokenizers/entity_default.json"
+    )
+    sample = EntityPayloadSample(
+        feature_names_per_table={
+            "district": ["district__hour", "district__some_new_thing"],
+            "building": [
+                "non_shiftable_load",
+                "solar_generation",
+                "electrical_storage_soc",
+                "electrical_storage_soc_ratio",
+            ],
+            "storage": [],
+            "charger": [],
+            "pv": [],
+            "ev": [],
+        },
+    )
+    with pytest.raises(ValueError, match="district__some_new_thing"):
+        validate_against_payload(
+            cfg,
+            sample,
+            [["electrical_storage", "electric_vehicle_storage"]],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rule 2 — uniqueness
+# ---------------------------------------------------------------------------
+
+
+def test_rule2_ambiguous_pattern_fails():
+    from utils.entity_tokenizer_schema import (
+        EntityTokenizerConfig,
+        _load_default_sample,
+        validate_against_payload,
+    )
+
+    cfg_dict = json.loads(
+        Path("configs/tokenizers/entity_default.json").read_text()
+    )
+    cfg_dict["sro_types"]["district_time_dup"] = {
+        "entity_table": "district",
+        "cardinality": "singleton",
+        "feature_patterns": ["^district__hour$"],
+        "input_dim_fallback": 1,
+    }
+    cfg = EntityTokenizerConfig.model_validate(cfg_dict)
+    with pytest.raises(
+        ValueError,
+        match=r"district__hour.*district_time.*district_time_dup|district_time_dup.*district_time",
+    ):
+        validate_against_payload(
+            cfg,
+            _load_default_sample(),
+            [["electrical_storage", "electric_vehicle_storage"]],
+        )
+
+
+def test_excluded_feature_cannot_match_an_sro_type():
+    """If a feature matches both excluded and an SRO pattern, rule 2 catches it."""
+    from utils.entity_tokenizer_schema import (
+        EntityTokenizerConfig,
+        _load_default_sample,
+        validate_against_payload,
+    )
+
+    cfg_dict = json.loads(
+        Path("configs/tokenizers/entity_default.json").read_text()
+    )
+    cfg_dict["sro_types"]["district_meta"]["feature_patterns"].append(
+        "^district__topology_version$"
+    )
+    cfg = EntityTokenizerConfig.model_validate(cfg_dict)
+    with pytest.raises(ValueError, match="district__topology_version"):
+        validate_against_payload(
+            cfg,
+            _load_default_sample(),
+            [["electrical_storage", "electric_vehicle_storage"]],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rule 3 — NFC sources
+# ---------------------------------------------------------------------------
+
+
+def test_rule3_missing_nfc_source_fails():
+    from utils.entity_tokenizer_schema import (
+        EntityTokenizerConfig,
+        _load_default_sample,
+        validate_against_payload,
+    )
+
+    cfg_dict = json.loads(
+        Path("configs/tokenizers/entity_default.json").read_text()
+    )
+    cfg_dict["nfc"]["expression"]["left"]["feature"] = "does_not_exist"
+    cfg = EntityTokenizerConfig.model_validate(cfg_dict)
+    with pytest.raises(ValueError, match="does_not_exist"):
+        validate_against_payload(
+            cfg,
+            _load_default_sample(),
+            [["electrical_storage", "electric_vehicle_storage"]],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rule 4 — regex compilation
+# ---------------------------------------------------------------------------
+
+
+def test_rule4_bad_regex_fails():
+    from utils.entity_tokenizer_schema import (
+        EntityTokenizerConfig,
+        _load_default_sample,
+        validate_against_payload,
+    )
+
+    cfg_dict = json.loads(
+        Path("configs/tokenizers/entity_default.json").read_text()
+    )
+    cfg_dict["sro_types"]["district_time"]["feature_patterns"] = ["^[unclosed"]
+    cfg = EntityTokenizerConfig.model_validate(cfg_dict)
+    with pytest.raises(
+        ValueError, match=r"sro_types\.district_time\.feature_patterns"
+    ):
+        validate_against_payload(
+            cfg,
+            _load_default_sample(),
+            [["electrical_storage", "electric_vehicle_storage"]],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rule 5 — action-field coverage
+# ---------------------------------------------------------------------------
+
+
+def test_rule5_missing_action_field_fails():
+    from utils.entity_tokenizer_schema import (
+        _load_default_sample,
+        load_entity_tokenizer_config,
+        validate_against_payload,
+    )
+
+    cfg = load_entity_tokenizer_config(
+        "configs/tokenizers/entity_default.json"
+    )
+    sample = _load_default_sample()
+    # Building 0 missing the charger action_field.
+    bad_action_names = [["electrical_storage"]]
+    with pytest.raises(ValueError, match="electric_vehicle_storage"):
+        validate_against_payload(cfg, sample, bad_action_names)
+
+
+def test_rule5_default_passes():
+    from utils.entity_tokenizer_schema import (
+        _load_default_sample,
+        load_entity_tokenizer_config,
+        validate_against_payload,
+    )
+
+    cfg = load_entity_tokenizer_config(
+        "configs/tokenizers/entity_default.json"
+    )
+    sample = _load_default_sample()
+    action_names = [["electrical_storage", "electric_vehicle_storage"]]
+    validate_against_payload(cfg, sample, action_names)
+
+
+# ---------------------------------------------------------------------------
+# Excluded patterns matcher
+# ---------------------------------------------------------------------------
+
+
+def test_excluded_pattern_matches_topology_version():
+    from utils.entity_tokenizer_schema import (
+        _excluded_matchers,
+        load_entity_tokenizer_config,
+    )
+
+    cfg = load_entity_tokenizer_config(
+        "configs/tokenizers/entity_default.json"
+    )
+    matchers = _excluded_matchers(cfg)
+    assert any(p.fullmatch("district__topology_version") for p in matchers)
+    assert any(
+        p.fullmatch("electric_vehicle_charger_state") for p in matchers
+    )
+    assert not any(p.fullmatch("district__hour") for p in matchers)
+
+

--- a/utils/entity_tokenizer_schema.py
+++ b/utils/entity_tokenizer_schema.py
@@ -1,0 +1,377 @@
+"""Pydantic models, loader, and validation rules for the entity tokenizer config.
+
+Pure-Python (no torch). Consumed at config-validation time by
+:func:`utils.config_schema.validate_config` and re-used at runtime by
+``AgentTransformerPPO`` when the wrapper notifies a topology change.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Literal, Mapping, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class _Strict(BaseModel):
+    """Forbid unknown fields anywhere — catches typos in user config."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class NfcOperandConfig(_Strict):
+    feature: str
+
+
+class NfcExpressionConfig(_Strict):
+    op: Literal["subtract"]
+    left: NfcOperandConfig
+    right: NfcOperandConfig
+
+
+class NfcConfig(_Strict):
+    type_name: str
+    entity_table: str
+    expression: NfcExpressionConfig
+
+
+class CaTypeConfig(_Strict):
+    entity_table: str
+    action_field: str
+    input_dim_fallback: int = Field(ge=1)
+
+
+class SroSingletonTypeConfig(_Strict):
+    entity_table: str
+    cardinality: Literal["singleton"]
+    feature_patterns: List[str]
+    input_dim_fallback: int = Field(ge=1)
+
+
+class SroPerAssetTypeConfig(_Strict):
+    entity_table: str
+    cardinality: Literal["per_asset"]
+    adapter_prefix: str
+    adapter_label: Optional[str] = None
+    input_dim_fallback: int = Field(ge=1)
+
+
+SroTypeConfig = Union[SroSingletonTypeConfig, SroPerAssetTypeConfig]
+
+
+class ExcludedFeaturesConfig(_Strict):
+    patterns: List[str]
+
+
+class _ValidationFlags(_Strict):
+    unmatched_features: Literal["fail"]
+    ambiguous_pattern_match: Literal["fail"]
+    input_dim_mismatch: Literal["fail"]
+
+
+class EntityTokenizerConfig(_Strict):
+    """Top-level entity tokenizer configuration."""
+
+    type_embeddings: Dict[str, int]
+    excluded_features: ExcludedFeaturesConfig
+    nfc: NfcConfig
+    ca_types: Dict[str, CaTypeConfig]
+    sro_types: Dict[str, SroTypeConfig]
+    validation: _ValidationFlags
+
+    @field_validator("type_embeddings")
+    @classmethod
+    def _check_type_embeddings(cls, v: Dict[str, int]) -> Dict[str, int]:
+        expected = {"SRO": 0, "NFC": 1, "CA": 2}
+        if v != expected:
+            raise ValueError(
+                f"type_embeddings must equal {expected!r}, got {v!r}"
+            )
+        return v
+
+    @model_validator(mode="after")
+    def _require_storage_and_charger(self) -> "EntityTokenizerConfig":
+        missing = {"storage", "charger"} - set(self.ca_types)
+        if missing:
+            raise ValueError(
+                f"ca_types missing required entries: {sorted(missing)}"
+            )
+        return self
+
+
+def load_entity_tokenizer_config(path: str | Path) -> EntityTokenizerConfig:
+    """Read the JSON file at ``path`` and validate it as an EntityTokenizerConfig."""
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    return EntityTokenizerConfig.model_validate(raw)
+
+
+@dataclass(frozen=True)
+class EntityPayloadSample:
+    """Lightweight view of an entity payload used for tokenizer validation.
+
+    Only feature names (not values) are needed for rules 1–5; this lets the
+    validator run before any wrapper/simulator instantiation.
+    """
+
+    feature_names_per_table: Dict[str, List[str]]
+    # Per-asset adapter labels we have observed in the sample, e.g.
+    # {"pv": ["Building_1/pv", ...], "charger": ["Building_1/charger_1", ...]}.
+    # Currently only used as carry-through metadata.
+    adapter_observed_prefixes: Dict[str, List[str]] = field(default_factory=dict)
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_SAMPLE_PATH = _REPO_ROOT / "configs" / "tokenizers" / "fixtures" / "entity_obs_sample.json"
+
+
+def _load_default_sample() -> EntityPayloadSample:
+    """Load the bundled entity payload sample as an EntityPayloadSample.
+
+    The sample lives at ``configs/tokenizers/fixtures/entity_obs_sample.json``
+    and is the single canonical fixture for tokenizer validation.
+
+    The entity payload stores **bare** feature column names per table (e.g.
+    ``hour`` in the district table). The tokenizer config matches against
+    **adapter-emitted** names (see ``utils/entity_adapter.py:215``), where
+    district columns are prefixed ``district__<feature>`` and building columns
+    are emitted unprefixed. This loader applies that prefixing convention so
+    the validation rules see the same names the agent sees at runtime.
+    """
+    payload = json.loads(_DEFAULT_SAMPLE_PATH.read_text(encoding="utf-8"))
+    tables = payload["tables"]
+    feature_names_per_table: Dict[str, List[str]] = {}
+    # Match utils/entity_adapter.py: only the district block is prefixed when
+    # adapted into per-building observation names. All other tables keep bare
+    # column names; per-asset prefixing (storage::, pv::, charger::) is *not*
+    # applied to the per-table feature lists used by SRO singleton matchers
+    # (those operate on the asset's column names directly).
+    table_prefix = {
+        "district": "district__",
+    }
+    for table_name, table in tables.items():
+        if not isinstance(table, dict):
+            continue
+        features = table.get("features")
+        if not isinstance(features, list):
+            continue
+        prefix = table_prefix.get(table_name, "")
+        feature_names_per_table[table_name] = [
+            f"{prefix}{name}" for name in features
+        ]
+    return EntityPayloadSample(
+        feature_names_per_table=feature_names_per_table,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Five hard-fail validation rules
+# ---------------------------------------------------------------------------
+
+
+def _compile_pattern(pattern: str, json_path: str) -> re.Pattern[str]:
+    """Compile a regex; on failure raise ValueError with the originating path.
+
+    This is rule 4 (regex compilation): malformed patterns surface here before
+    any other rule is evaluated.
+    """
+    try:
+        return re.compile(pattern)
+    except re.error as exc:
+        raise ValueError(
+            f"Invalid regex at {json_path}: {pattern!r} -> {exc}"
+        ) from exc
+
+
+def _excluded_matchers(cfg: EntityTokenizerConfig) -> List[re.Pattern[str]]:
+    return [
+        _compile_pattern(p, f"excluded_features.patterns[{i}]")
+        for i, p in enumerate(cfg.excluded_features.patterns)
+    ]
+
+
+def _sro_matchers(
+    cfg: EntityTokenizerConfig,
+) -> Dict[str, List[re.Pattern[str]]]:
+    out: Dict[str, List[re.Pattern[str]]] = {}
+    for type_name, sro in cfg.sro_types.items():
+        if isinstance(sro, SroSingletonTypeConfig):
+            out[type_name] = [
+                _compile_pattern(
+                    p, f"sro_types.{type_name}.feature_patterns[{i}]"
+                )
+                for i, p in enumerate(sro.feature_patterns)
+            ]
+    return out
+
+
+def _classify_feature(
+    feature: str,
+    table: str,
+    cfg: EntityTokenizerConfig,
+    sro_matchers: Mapping[str, List[re.Pattern[str]]],
+    excluded_matchers: List[re.Pattern[str]],
+) -> List[str]:
+    """Return the labels a feature matches: ``"excluded"``, ``"nfc"``, or SRO type names.
+
+    Empty list = unmatched. More than one label = ambiguous.
+    """
+    labels: List[str] = []
+    if any(p.fullmatch(feature) for p in excluded_matchers):
+        labels.append("excluded")
+    if (
+        table == cfg.nfc.entity_table
+        and feature in (
+            cfg.nfc.expression.left.feature,
+            cfg.nfc.expression.right.feature,
+        )
+    ):
+        labels.append("nfc")
+    for sro_name, sro in cfg.sro_types.items():
+        if not isinstance(sro, SroSingletonTypeConfig):
+            continue
+        if sro.entity_table != table:
+            continue
+        if any(p.fullmatch(feature) for p in sro_matchers.get(sro_name, [])):
+            labels.append(sro_name)
+    return labels
+
+
+def _validate_rule_3_nfc_sources_exist(
+    cfg: EntityTokenizerConfig, sample: EntityPayloadSample
+) -> None:
+    table = cfg.nfc.entity_table
+    available = set(sample.feature_names_per_table.get(table, []))
+    declared = [
+        cfg.nfc.expression.left.feature,
+        cfg.nfc.expression.right.feature,
+    ]
+    missing = [m for m in declared if m not in available]
+    if missing:
+        raise ValueError(
+            f"Tokenizer rule 3 (nfc sources exist) failed — features "
+            f"{missing!r} are not present in entity_table {table!r}."
+        )
+
+
+def _validate_rule_1_coverage(
+    cfg: EntityTokenizerConfig,
+    sample: EntityPayloadSample,
+    sro_matchers: Mapping[str, List[re.Pattern[str]]],
+    excluded_matchers: List[re.Pattern[str]],
+) -> None:
+    referenced_tables = {cfg.nfc.entity_table}
+    for sro in cfg.sro_types.values():
+        if isinstance(sro, SroSingletonTypeConfig):
+            referenced_tables.add(sro.entity_table)
+    unmatched: List[tuple[str, str]] = []  # (table, feature)
+    for table in referenced_tables:
+        for feature in sample.feature_names_per_table.get(table, []):
+            labels = _classify_feature(
+                feature, table, cfg, sro_matchers, excluded_matchers
+            )
+            if not labels:
+                unmatched.append((table, feature))
+    if unmatched:
+        bullets = "\n".join(
+            f"  - table={t!r}, feature={f!r}" for t, f in unmatched
+        )
+        raise ValueError(
+            "Tokenizer rule 1 (coverage) failed — the following features are "
+            "not matched by any SRO type, NFC source, or excluded pattern:\n"
+            f"{bullets}\n"
+            "Fix: add to an existing SRO type's feature_patterns, define a "
+            "new SRO type, or add to excluded_features.patterns."
+        )
+
+
+def _validate_rule_2_uniqueness(
+    cfg: EntityTokenizerConfig,
+    sample: EntityPayloadSample,
+    sro_matchers: Mapping[str, List[re.Pattern[str]]],
+    excluded_matchers: List[re.Pattern[str]],
+) -> None:
+    referenced_tables = {cfg.nfc.entity_table}
+    for sro in cfg.sro_types.values():
+        if isinstance(sro, SroSingletonTypeConfig):
+            referenced_tables.add(sro.entity_table)
+    conflicts: List[tuple[str, str, List[str]]] = []
+    for table in referenced_tables:
+        for feature in sample.feature_names_per_table.get(table, []):
+            labels = _classify_feature(
+                feature, table, cfg, sro_matchers, excluded_matchers
+            )
+            if len(labels) > 1:
+                conflicts.append((table, feature, labels))
+    if conflicts:
+        bullets = "\n".join(
+            f"  - table={t!r}, feature={f!r}, matches={labels}"
+            for t, f, labels in conflicts
+        )
+        raise ValueError(
+            "Tokenizer rule 2 (uniqueness) failed — the following features "
+            "match more than one SRO type / NFC / excluded pattern:\n"
+            f"{bullets}\n"
+            "Fix: tighten the offending feature_patterns so each feature "
+            "belongs to exactly one bucket."
+        )
+
+
+def _validate_rule_5_action_field_coverage(
+    cfg: EntityTokenizerConfig,
+    action_names_per_building: List[List[str]],
+) -> None:
+    """Rule 5 (action-field coverage).
+
+    Every ``ca_types[*].action_field`` declared in the tokenizer config must
+    appear in at least one building's ``action_names``. Per-building gaps are
+    expected (e.g. assets-only datasets where some buildings have no
+    charger), so we enforce coverage at the *dataset* level rather than the
+    per-building level. The per-building post-condition is enforced by
+    ``EntityTokenLayoutBuilder`` via the count match
+    (``len(ca_segments) == len(action_names)``); a building that lacks a
+    given CA simply has no segment for that type.
+    """
+    required = {ca.action_field for ca in cfg.ca_types.values()}
+    declared = {n for names in action_names_per_building for n in names}
+    missing = sorted(r for r in required if r not in declared)
+    if missing:
+        raise ValueError(
+            "Tokenizer rule 5 (action-field coverage) failed — the following "
+            "CA action_fields declared in ca_types do not appear in any "
+            f"building's action_names:\n"
+            + "\n".join(f"  - {m!r}" for m in missing)
+            + "\nFix: either remove the unused ca_type from the tokenizer "
+            "config, or ensure the simulator schema declares the "
+            "corresponding asset on at least one building."
+        )
+
+
+def validate_against_payload(
+    cfg: EntityTokenizerConfig,
+    sample: EntityPayloadSample,
+    action_names_per_building: List[List[str]],
+    *,
+    include_rule_5: bool = True,
+) -> None:
+    """Run hard-fail validation rules. Raises ``ValueError`` on first failure.
+
+    Order: rule 4 (regex compile) is implicit during matcher construction;
+    then rule 3 (NFC sources exist); then rule 1 (coverage); then rule 2
+    (uniqueness); then optionally rule 5 (action-field coverage).
+
+    ``include_rule_5`` controls whether the dataset-level action-field
+    coverage check runs. Callers SHOULD enable it at startup (to catch
+    misconfigured tokenizers vs the simulator schema) but MAY disable it
+    when re-validating after a runtime topology mutation, where the set of
+    active assets can legitimately become a strict subset of the configured
+    CA types (e.g. a topology event removes the last EV charger).
+    """
+    sro_matchers = _sro_matchers(cfg)
+    excluded_matchers = _excluded_matchers(cfg)
+    _validate_rule_3_nfc_sources_exist(cfg, sample)
+    _validate_rule_1_coverage(cfg, sample, sro_matchers, excluded_matchers)
+    _validate_rule_2_uniqueness(cfg, sample, sro_matchers, excluded_matchers)
+    if include_rule_5:
+        _validate_rule_5_action_field_coverage(cfg, action_names_per_building)


### PR DESCRIPTION
Adds the entity tokenizer configuration layer and its validation rules without changing any existing code path. This is the foundation for the v2 Universal Local Controller.

New
- docs/specv2.md: v2 spec (entity interface, dynamic topology).
- utils/entity_tokenizer_schema.py: pydantic models for the tokenizer JSON, 5 hard-fail validation rules, payload-sample loader.
- configs/tokenizers/entity_default.json: production tokenizer config for the citylearn_three_phase_dynamic_assets_only_demo dataset.
- configs/tokenizers/fixtures/entity_obs_sample.json: bundled payload sample used by tokenizer validation (rows trimmed to ids; features and edges preserved).
- tests/test_entity_tokenizer_config_schema.py: 13 tests covering the pydantic models, rules 1-5, and the excluded-patterns matcher.
- tests/_entity_sample_obs_names.py: test helper that synthesises the per-building observation_names emission order from the bundled sample without requiring a CityLearn env.