### PR TITLE
Gj/wp06 02 layout builder

### DIFF
--- a/algorithms/utils/entity_token_layout.py
+++ b/algorithms/utils/entity_token_layout.py
@@ -1,0 +1,486 @@
+"""EntityTokenLayoutBuilder — pure-Python token segmentation.
+
+No torch / numpy / pydantic / algorithms.* / utils.* imports — this module
+is portable to the inference repo.
+
+The builder is **passive**: it consumes per-building observation/action
+names that the wrapper has already produced and returns a deterministic
+``BuildingTokenLayout``. CA segments are permuted to match ``action_names``
+position-by-position; this is the single source of truth that the agent's
+startup assertion checks.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NfcExpression:
+    """Compiled NFC computation: ``op(features[left], features[right])``.
+
+    Indices are offsets into the owning ``TokenSegment.feature_indices``,
+    NOT absolute observation indices.
+    """
+
+    op: str
+    left_index_in_segment: int
+    right_index_in_segment: int
+
+
+@dataclass(frozen=True)
+class TokenSegment:
+    """One token's worth of slice metadata into the per-building observation.
+
+    ``feature_indices`` is a tuple (so it is hashable) and supports
+    non-contiguous selection — important for interleaved district forecast
+    feature groups.
+    """
+
+    family: str  # "sro" | "nfc" | "ca"
+    type_name: str
+    instance_id: Optional[str]
+    feature_indices: Tuple[int, ...]
+    feature_names: Tuple[str, ...]
+    derived: Optional[NfcExpression] = None
+
+
+@dataclass(frozen=True)
+class BuildingTokenLayout:
+    """Deterministic layout for a single building.
+
+    ``ca_action_names`` MUST equal ``tuple(action_names[building])`` element
+    by element — enforced at construction time so the agent's startup
+    assertion is a redundant check, not the first failure point.
+    """
+
+    building_id: str
+    segments: Tuple[TokenSegment, ...]
+    n_sro: int
+    n_ca: int
+    ca_action_names: Tuple[str, ...]
+    excluded_feature_names: Tuple[str, ...]
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+# Per-asset adapter prefixes use "::" as separator (see utils/entity_adapter.py).
+# Two id forms appear in adapter output:
+#   pv::Building_1/pv::generation_power_kw                  → unlabelled
+#   charger::Building_1/C1::power_kw                        → unlabelled
+#   storage::Building_1/storage::soc                        → unlabelled
+#   charger::Building_1/C1::connected_ev::soc               → labelled
+#   charger::Building_1/C1::incoming_ev::soc                → labelled
+_PER_ASSET_LABELLED_RE = re.compile(
+    r"^(?P<prefix>charger)::(?P<id>[^:]+(?:/[^:]+)*)::"
+    r"(?P<label>connected_ev|incoming_ev)::(?P<feature>.+)$"
+)
+_PER_ASSET_UNLABELLED_RE = re.compile(
+    r"^(?P<prefix>pv|storage|charger|deferrable_appliance)::(?P<id>[^:]+(?:/[^:]+)*)::"
+    r"(?P<feature>(?!connected_ev::|incoming_ev::).+)$"
+)
+_DISTRICT_PREFIX = "district__"
+
+
+def _compile_pattern(pattern: str, json_path: str) -> "re.Pattern[str]":
+    """Compile a regex with a contextual error path."""
+    try:
+        return re.compile(pattern)
+    except re.error as exc:
+        raise ValueError(
+            f"Invalid regex at {json_path}: {pattern!r} -> {exc}"
+        ) from exc
+
+
+def _build_excluded_matchers(tokenizer_config: Any) -> List["re.Pattern[str]"]:
+    """Compile excluded_features.patterns. Lifted from
+    ``utils/entity_tokenizer_schema.py`` so this module stays portable
+    (no schema-module import allowed)."""
+    return [
+        _compile_pattern(p, f"excluded_features.patterns[{i}]")
+        for i, p in enumerate(tokenizer_config.excluded_features.patterns)
+    ]
+
+
+def _build_sro_matchers(
+    tokenizer_config: Any,
+) -> Dict[str, List["re.Pattern[str]"]]:
+    """Compile feature_patterns for every singleton SRO type (same
+    portability rationale as above)."""
+    out: Dict[str, List["re.Pattern[str]"]] = {}
+    for type_name, sro in tokenizer_config.sro_types.items():
+        # Skip per-asset entries; they have no feature_patterns.
+        if getattr(sro, "cardinality", None) != "singleton":
+            continue
+        out[type_name] = [
+            _compile_pattern(
+                p, f"sro_types.{type_name}.feature_patterns[{i}]"
+            )
+            for i, p in enumerate(sro.feature_patterns)
+        ]
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+
+
+class EntityTokenLayoutBuilder:
+    """Builds per-building TokenLayout. Caches by
+    ``(building_id, observation_names, action_names)``."""
+
+    def __init__(self, tokenizer_config: Any) -> None:
+        self._cfg = tokenizer_config
+        self._cache: Dict[
+            Tuple[str, Tuple[str, ...], Tuple[str, ...]], BuildingTokenLayout
+        ] = {}
+        self._sro_matchers = _build_sro_matchers(tokenizer_config)
+        self._excluded_matchers = _build_excluded_matchers(tokenizer_config)
+        # SRO declaration order = order of insertion into the JSON dict
+        # (preserved by Python 3.7+ dict semantics).
+        self._sro_declaration_order: Dict[str, int] = {
+            name: i for i, name in enumerate(tokenizer_config.sro_types.keys())
+        }
+        # action_field per CA type (storage → electrical_storage, etc.)
+        self._ca_action_field_by_type: Dict[str, str] = {
+            type_name: ca.action_field
+            for type_name, ca in tokenizer_config.ca_types.items()
+        }
+        # Adapter prefix (e.g. "storage", "charger") → CA type_name.
+        self._ca_prefix_to_type: Dict[str, str] = {
+            "storage": "storage",
+            "charger": "charger",
+        }
+
+    # ------------------------------------------------------------------
+    # public surface
+    # ------------------------------------------------------------------
+
+    def build(
+        self,
+        building_id: str,
+        observation_names: Sequence[str],
+        action_names: Sequence[str],
+    ) -> BuildingTokenLayout:
+        key = (building_id, tuple(observation_names), tuple(action_names))
+        cached = self._cache.get(key)
+        if cached is not None:
+            return cached
+        layout = self._compute_layout(
+            building_id, list(observation_names), list(action_names)
+        )
+        self._cache[key] = layout
+        return layout
+
+    def topology_changed(
+        self,
+        building_id: str,
+        observation_names: Sequence[str],
+        action_names: Sequence[str],
+    ) -> bool:
+        """Cheap predicate: ``True`` iff no cached layout exists for this
+        exact ``(building, observation_names, action_names)`` combination."""
+        key = (building_id, tuple(observation_names), tuple(action_names))
+        return key not in self._cache
+
+    # ------------------------------------------------------------------
+    # internals
+    # ------------------------------------------------------------------
+
+    def _compute_layout(
+        self,
+        building_id: str,
+        observation_names: List[str],
+        action_names: List[str],
+    ) -> BuildingTokenLayout:
+        # --- Step 1: drop excluded features --------------------------------
+        excluded_names: List[str] = []
+        keep_indices: List[int] = []
+        for i, name in enumerate(observation_names):
+            if any(p.fullmatch(name) for p in self._excluded_matchers):
+                excluded_names.append(name)
+            else:
+                keep_indices.append(i)
+
+        # --- Step 2: detect NFC sources ------------------------------------
+        nfc_left = self._cfg.nfc.expression.left.feature
+        nfc_right = self._cfg.nfc.expression.right.feature
+        idx_left: Optional[int] = None
+        idx_right: Optional[int] = None
+        for i in keep_indices:
+            name = observation_names[i]
+            if name == nfc_left and idx_left is None:
+                idx_left = i
+            elif name == nfc_right and idx_right is None:
+                idx_right = i
+        if idx_left is None or idx_right is None:
+            raise ValueError(
+                f"NFC sources missing for building {building_id!r}: "
+                f"left={nfc_left!r} (found={idx_left is not None}), "
+                f"right={nfc_right!r} (found={idx_right is not None})"
+            )
+        nfc_segment = TokenSegment(
+            family="nfc",
+            type_name=self._cfg.nfc.type_name,
+            instance_id=building_id,
+            feature_indices=(idx_left, idx_right),
+            feature_names=(nfc_left, nfc_right),
+            derived=NfcExpression(
+                op=self._cfg.nfc.expression.op,
+                left_index_in_segment=0,
+                right_index_in_segment=1,
+            ),
+        )
+        # NFC sources consumed → exclude from SRO classification.
+        sro_candidates = [
+            i for i in keep_indices if i != idx_left and i != idx_right
+        ]
+
+        # --- Steps 3-4: classify each remaining feature into SRO or CA -----
+        sro_buckets: Dict[Tuple[str, str], List[Tuple[int, str]]] = {}
+        ca_buckets: Dict[Tuple[str, str], List[Tuple[int, str]]] = {}
+        unmatched: List[str] = []
+
+        for i in sro_candidates:
+            name = observation_names[i]
+            classification = self._classify_one(name, building_id)
+            if classification is None:
+                unmatched.append(name)
+            else:
+                family, type_name, instance_id = classification
+                bucket = sro_buckets if family == "sro" else ca_buckets
+                bucket.setdefault((type_name, instance_id), []).append(
+                    (i, name)
+                )
+
+        # --- Step 5: hard-fail on leftovers ---
+        if unmatched:
+            bullets = "\n".join(f"  - {n!r}" for n in unmatched)
+            raise ValueError(
+                f"Tokenizer rule 1 (coverage) failed at runtime for building "
+                f"{building_id!r} — the following observation names did not "
+                f"match any SRO type, NFC source, or excluded pattern:\n"
+                f"{bullets}\n"
+                "Add to a feature_pattern, NFC source, or "
+                "excluded_features.patterns."
+            )
+
+        # --- Order: SROs by (declaration_order, instance_id), then NFC,
+        # then CAs in action_names order. -----------------------------------
+        sro_segments: List[TokenSegment] = []
+        for (type_name, instance_id), feats in sorted(
+            sro_buckets.items(),
+            key=lambda kv: (
+                self._sro_declaration_order[kv[0][0]],
+                kv[0][1] or "",
+            ),
+        ):
+            indices = tuple(idx for idx, _ in feats)
+            names = tuple(n for _, n in feats)
+            sro_segments.append(
+                TokenSegment(
+                    family="sro",
+                    type_name=type_name,
+                    instance_id=instance_id,
+                    feature_indices=indices,
+                    feature_names=names,
+                )
+            )
+
+        ca_segments_unordered: List[TokenSegment] = []
+        for (type_name, instance_id), feats in ca_buckets.items():
+            indices = tuple(idx for idx, _ in feats)
+            names = tuple(n for _, n in feats)
+            ca_segments_unordered.append(
+                TokenSegment(
+                    family="ca",
+                    type_name=type_name,
+                    instance_id=instance_id,
+                    feature_indices=indices,
+                    feature_names=names,
+                )
+            )
+
+        ca_segments = self._order_cas_by_action_names(
+            ca_segments_unordered, list(action_names), building_id
+        )
+
+        segments = (
+            tuple(sro_segments) + (nfc_segment,) + tuple(ca_segments)
+        )
+        ca_action_names = tuple(
+            self._ca_action_field_by_type[seg.type_name]
+            for seg in ca_segments
+        )
+        # Defensive post-condition (the orderer guarantees this).
+        # Each entry of ``ca_action_names`` (the segment's action_field) must
+        # either equal the corresponding ``action_name`` exactly, or be a
+        # ``"<action_field>_<instance_id>"`` prefix of it (CityLearn appends
+        # a charger-id suffix when multiple CAs of the same type exist).
+        for af, an in zip(ca_action_names, action_names):
+            if an == af:
+                continue
+            if an.startswith(af + "_"):
+                continue
+            raise ValueError(
+                f"BuildingTokenLayout.ca_action_names {ca_action_names!r} "
+                f"does not match action_names[{building_id}] "
+                f"{tuple(action_names)!r}"
+            )
+        return BuildingTokenLayout(
+            building_id=building_id,
+            segments=segments,
+            n_sro=len(sro_segments),
+            n_ca=len(ca_segments),
+            ca_action_names=ca_action_names,
+            excluded_feature_names=tuple(excluded_names),
+        )
+
+    def _classify_one(
+        self, name: str, building_id: str
+    ) -> Optional[Tuple[str, str, str]]:
+        """Return ``(family, type_name, instance_id)`` or ``None``.
+
+        Hard-fails on ambiguous singleton SRO matches.
+        """
+        # Per-asset (labelled) → ev_connected / ev_incoming SRO.
+        m_lab = _PER_ASSET_LABELLED_RE.fullmatch(name)
+        if m_lab is not None:
+            label = m_lab.group("label")
+            instance_id = m_lab.group("id")
+            sro_type = (
+                "ev_connected" if label == "connected_ev" else "ev_incoming"
+            )
+            return ("sro", sro_type, instance_id)
+
+        # Per-asset (unlabelled) → CA (storage/charger) or per-asset SRO (pv).
+        m_un = _PER_ASSET_UNLABELLED_RE.fullmatch(name)
+        if m_un is not None:
+            prefix = m_un.group("prefix")
+            instance_id = m_un.group("id")
+            if prefix in self._ca_prefix_to_type:
+                return ("ca", self._ca_prefix_to_type[prefix], instance_id)
+            if prefix == "pv":
+                return ("sro", "pv", instance_id)
+            if prefix == "deferrable_appliance":
+                return ("sro", "deferrable_appliance", instance_id)
+
+        # Singleton SRO match (district or building scoped). Collect ALL
+        # matches to detect ambiguity.
+        matches: List[str] = []
+        for sro_name, patterns in self._sro_matchers.items():
+            if any(p.fullmatch(name) for p in patterns):
+                matches.append(sro_name)
+        if len(matches) > 1:
+            raise ValueError(
+                f"Tokenizer rule 2 (uniqueness) violated at runtime: "
+                f"observation name {name!r} matches multiple SRO types "
+                f"{matches}. Tighten feature_patterns in the tokenizer config."
+            )
+        if matches:
+            return ("sro", matches[0], building_id)
+        return None
+
+    def _order_cas_by_action_names(
+        self,
+        ca_segments: List[TokenSegment],
+        action_names: List[str],
+        building_id: str,
+    ) -> List[TokenSegment]:
+        """Sort CA segments so ``ca_action_names[i] == action_names[i]``.
+
+        Matching strategy (in order):
+
+        1. Exact match: ``action_name == action_field``. This holds when the
+           simulator emits unsuffixed names (e.g., ``electrical_storage`` for
+           the single building-level battery).
+        2. Prefix match: ``action_name == f"{action_field}_{instance_id}"``.
+           CityLearn appends a charger ID suffix when multiple CAs of the
+           same type exist (e.g.,
+           ``electric_vehicle_storage_charger_1_1``); we match by checking
+           ``action_name.startswith(action_field + "_")`` and verifying the
+           suffix equals the segment's ``instance_id``. Falls back to first
+           prefix-matching segment if exact instance match fails.
+
+        Within an action_field, segments are picked in sorted ``instance_id``
+        order for determinism (only relevant for the prefix fallback).
+        """
+        if len(ca_segments) != len(action_names):
+            raise ValueError(
+                f"CA count mismatch for building {building_id!r}: "
+                f"{len(ca_segments)} CA segments vs {len(action_names)} "
+                f"action names (actions={action_names!r})"
+            )
+        by_action_field: Dict[str, List[TokenSegment]] = {}
+        for seg in ca_segments:
+            af = self._ca_action_field_by_type[seg.type_name]
+            by_action_field.setdefault(af, []).append(seg)
+        for v in by_action_field.values():
+            v.sort(key=lambda s: s.instance_id or "")
+
+        # Build (action_field, action_name) pairs by matching each action
+        # name to its action_field via exact-or-prefix.
+        all_action_fields = set(by_action_field.keys())
+        ordered: List[TokenSegment] = []
+        # Track which segments we've already consumed (by id()) so each one
+        # is used exactly once.
+        consumed_ids: set = set()
+        for action_name in action_names:
+            chosen_field: Optional[str] = None
+            if action_name in all_action_fields:
+                chosen_field = action_name
+            else:
+                # Prefix match: action_name = f"{action_field}_{instance_id}"
+                candidates = [
+                    af for af in all_action_fields
+                    if action_name.startswith(af + "_")
+                ]
+                if len(candidates) == 1:
+                    chosen_field = candidates[0]
+                elif len(candidates) > 1:
+                    # Ambiguity: pick the longest matching prefix.
+                    chosen_field = max(candidates, key=len)
+            if chosen_field is None:
+                raise ValueError(
+                    f"Cannot map action_name {action_name!r} to any "
+                    f"action_field in {sorted(all_action_fields)} for "
+                    f"building {building_id!r}"
+                )
+
+            # Find the next unconsumed segment in this action_field's pool.
+            # Prefer instance_id == suffix-of-action_name when present.
+            pool = by_action_field[chosen_field]
+            suffix = action_name[len(chosen_field) + 1 :] if action_name != chosen_field else None
+            picked: Optional[TokenSegment] = None
+            if suffix:
+                for seg in pool:
+                    if id(seg) in consumed_ids:
+                        continue
+                    if seg.instance_id == suffix:
+                        picked = seg
+                        break
+            if picked is None:
+                # Fall back to first unconsumed segment in deterministic order.
+                for seg in pool:
+                    if id(seg) not in consumed_ids:
+                        picked = seg
+                        break
+            if picked is None:
+                raise ValueError(
+                    f"Cannot satisfy action_names ordering for building "
+                    f"{building_id!r}: ran out of CA segments for "
+                    f"action_field {chosen_field!r} (have {len(pool)})"
+                )
+            ordered.append(picked)
+            consumed_ids.add(id(picked))
+        return ordered

--- a/algorithms/utils/entity_token_layout.py
+++ b/algorithms/utils/entity_token_layout.py
@@ -6,8 +6,7 @@ is portable to the inference repo.
 The builder is **passive**: it consumes per-building observation/action
 names that the wrapper has already produced and returns a deterministic
 ``BuildingTokenLayout``. CA segments are permuted to match ``action_names``
-position-by-position; this is the single source of truth that the agent's
-startup assertion checks.
+position-by-position; the invariant is enforced at construction time.
 """
 from __future__ import annotations
 
@@ -56,8 +55,7 @@ class BuildingTokenLayout:
     """Deterministic layout for a single building.
 
     ``ca_action_names`` MUST equal ``tuple(action_names[building])`` element
-    by element — enforced at construction time so the agent's startup
-    assertion is a redundant check, not the first failure point.
+    by element — enforced at construction time.
     """
 
     building_id: str
@@ -88,7 +86,6 @@ _PER_ASSET_UNLABELLED_RE = re.compile(
     r"^(?P<prefix>pv|storage|charger|deferrable_appliance)::(?P<id>[^:]+(?:/[^:]+)*)::"
     r"(?P<feature>(?!connected_ev::|incoming_ev::).+)$"
 )
-_DISTRICT_PREFIX = "district__"
 
 
 def _compile_pattern(pattern: str, json_path: str) -> "re.Pattern[str]":
@@ -181,17 +178,6 @@ class EntityTokenLayoutBuilder:
         )
         self._cache[key] = layout
         return layout
-
-    def topology_changed(
-        self,
-        building_id: str,
-        observation_names: Sequence[str],
-        action_names: Sequence[str],
-    ) -> bool:
-        """Cheap predicate: ``True`` iff no cached layout exists for this
-        exact ``(building, observation_names, action_names)`` combination."""
-        key = (building_id, tuple(observation_names), tuple(action_names))
-        return key not in self._cache
 
     # ------------------------------------------------------------------
     # internals
@@ -406,14 +392,14 @@ class EntityTokenLayoutBuilder:
            the single building-level battery).
         2. Prefix match: ``action_name == f"{action_field}_{instance_id}"``.
            CityLearn appends a charger ID suffix when multiple CAs of the
-           same type exist (e.g.,
-           ``electric_vehicle_storage_charger_1_1``); we match by checking
-           ``action_name.startswith(action_field + "_")`` and verifying the
-           suffix equals the segment's ``instance_id``. Falls back to first
-           prefix-matching segment if exact instance match fails.
+           same type exist (e.g., ``electric_vehicle_storage_charger_1_1``).
+           If multiple action_fields could prefix-match, the longest one
+           wins.
 
         Within an action_field, segments are picked in sorted ``instance_id``
-        order for determinism (only relevant for the prefix fallback).
+        order. When the suffix of ``action_name`` matches a segment's
+        ``instance_id`` exactly, that segment is preferred; otherwise the
+        first unconsumed segment in sorted order is used.
         """
         if len(ca_segments) != len(action_names):
             raise ValueError(

--- a/tests/test_entity_token_layout.py
+++ b/tests/test_entity_token_layout.py
@@ -1,0 +1,486 @@
+"""Tests for ``EntityTokenLayoutBuilder``.
+
+Single-fixture style: most tests share a builder + Building_1 layout built
+from the bundled sample payload. Failure-mode tests build their own.
+"""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from tests._entity_sample_obs_names import (
+    load_sample_observation_names_for_first_building,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def cfg():
+    from utils.entity_tokenizer_schema import load_entity_tokenizer_config
+
+    return load_entity_tokenizer_config(
+        "configs/tokenizers/entity_default.json"
+    )
+
+
+@pytest.fixture
+def builder_and_obs(cfg):
+    from algorithms.utils.entity_token_layout import EntityTokenLayoutBuilder
+
+    builder = EntityTokenLayoutBuilder(cfg)
+    obs_names = load_sample_observation_names_for_first_building()
+    action_names = ["electrical_storage", "electric_vehicle_storage"]
+    layout = builder.build("Building_1", obs_names, action_names)
+    return builder, obs_names, layout
+
+
+def _find_segment(layout, family, type_name, instance_substr=None):
+    for s in layout.segments:
+        if s.family == family and s.type_name == type_name:
+            if instance_substr is None or instance_substr in (
+                s.instance_id or ""
+            ):
+                return s
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Smoke + happy-path
+# ---------------------------------------------------------------------------
+
+
+def test_dataclasses_constructible():
+    from algorithms.utils.entity_token_layout import (
+        BuildingTokenLayout,
+        NfcExpression,
+        TokenSegment,
+    )
+
+    seg = TokenSegment(
+        family="sro",
+        type_name="district_time",
+        instance_id="Building_1",
+        feature_indices=(0, 1, 2),
+        feature_names=(
+            "district__month",
+            "district__day_type",
+            "district__hour",
+        ),
+    )
+    nfc = NfcExpression(
+        op="subtract", left_index_in_segment=0, right_index_in_segment=1
+    )
+    layout = BuildingTokenLayout(
+        building_id="Building_1",
+        segments=(seg,),
+        n_sro=1,
+        n_ca=0,
+        ca_action_names=(),
+        excluded_feature_names=(),
+    )
+    assert layout.n_sro == 1
+    assert seg.derived is None
+    assert nfc.op == "subtract"
+
+
+def test_uses_real_sample_payload(builder_and_obs):
+    _, obs_names, layout = builder_and_obs
+    classified = set()
+    for seg in layout.segments:
+        classified.update(seg.feature_indices)
+    excluded = len(layout.excluded_feature_names)
+    assert len(classified) + excluded == len(obs_names), (
+        f"unclassified: total={len(obs_names)} "
+        f"classified={len(classified)} excluded={excluded}"
+    )
+    assert layout.ca_action_names == (
+        "electrical_storage",
+        "electric_vehicle_storage",
+    )
+
+
+# ---------------------------------------------------------------------------
+# ---
+# ---------------------------------------------------------------------------
+
+
+def test_classifies_district_time_to_sro_singleton(builder_and_obs):
+    _, obs, layout = builder_and_obs
+    seg = _find_segment(layout, "sro", "district_time")
+    assert seg is not None
+    assert obs.index("district__hour") in seg.feature_indices
+
+
+def test_classifies_district_pricing_current_separately_from_forecast(
+    builder_and_obs,
+):
+    _, obs, layout = builder_and_obs
+    cur = _find_segment(layout, "sro", "district_pricing_current")
+    fwd = _find_segment(layout, "sro", "district_pricing_forecast")
+    assert cur is not None and fwd is not None
+    assert obs.index("district__electricity_pricing") in cur.feature_indices
+    forecast_names = [n for n in obs if "electricity_pricing_predicted" in n]
+    assert any(obs.index(n) in fwd.feature_indices for n in forecast_names)
+
+
+def test_classifies_district_carbon_separately_from_pricing(builder_and_obs):
+    _, obs, layout = builder_and_obs
+    carbon = _find_segment(layout, "sro", "district_carbon")
+    cur = _find_segment(layout, "sro", "district_pricing_current")
+    fwd = _find_segment(layout, "sro", "district_pricing_forecast")
+    assert carbon is not None
+    idx = obs.index("district__carbon_intensity")
+    assert idx in carbon.feature_indices
+    assert idx not in (cur.feature_indices if cur else ())
+    assert idx not in (fwd.feature_indices if fwd else ())
+
+
+def test_classifies_building_storage_state_to_sro(builder_and_obs):
+    _, obs, layout = builder_and_obs
+    seg = _find_segment(layout, "sro", "building_storage_state")
+    assert seg is not None
+    assert obs.index("electrical_storage_soc") in seg.feature_indices
+    assert obs.index("electrical_storage_soc_ratio") in seg.feature_indices
+
+
+def test_classifies_per_asset_pv_to_sro(builder_and_obs):
+    _, obs, layout = builder_and_obs
+    pv_segs = [
+        s for s in layout.segments if s.family == "sro" and s.type_name == "pv"
+    ]
+    assert len(pv_segs) >= 1
+    pv_obs = [n for n in obs if n.startswith("pv::")]
+    classified = set()
+    for s in pv_segs:
+        classified.update(s.feature_indices)
+    for n in pv_obs:
+        assert obs.index(n) in classified
+
+
+def test_classifies_per_asset_ev_connected_to_sro(builder_and_obs):
+    _, _, layout = builder_and_obs
+    segs = [
+        s
+        for s in layout.segments
+        if s.family == "sro" and s.type_name == "ev_connected"
+    ]
+    assert len(segs) >= 1
+    for s in segs:
+        for n in s.feature_names:
+            assert "::connected_ev::" in n
+
+
+def test_classifies_per_asset_ev_incoming_to_sro(builder_and_obs):
+    _, _, layout = builder_and_obs
+    segs = [
+        s
+        for s in layout.segments
+        if s.family == "sro" and s.type_name == "ev_incoming"
+    ]
+    assert len(segs) >= 1
+    for s in segs:
+        for n in s.feature_names:
+            assert "::incoming_ev::" in n
+
+
+def test_classifies_storage_prefix_to_ca(builder_and_obs):
+    _, _, layout = builder_and_obs
+    segs = [
+        s
+        for s in layout.segments
+        if s.family == "ca" and s.type_name == "storage"
+    ]
+    assert len(segs) >= 1
+    for s in segs:
+        for n in s.feature_names:
+            assert n.startswith("storage::")
+
+
+def test_classifies_charger_prefix_to_ca(builder_and_obs):
+    _, _, layout = builder_and_obs
+    segs = [
+        s
+        for s in layout.segments
+        if s.family == "ca" and s.type_name == "charger"
+    ]
+    assert len(segs) >= 1
+    for s in segs:
+        for n in s.feature_names:
+            assert n.startswith("charger::")
+            assert "::connected_ev::" not in n
+            assert "::incoming_ev::" not in n
+
+
+# ---------------------------------------------------------------------------
+# ---
+# ---------------------------------------------------------------------------
+
+
+def test_nfc_segment_has_two_source_indices_and_subtract_op(builder_and_obs):
+    _, obs, layout = builder_and_obs
+    nfc = next((s for s in layout.segments if s.family == "nfc"), None)
+    assert nfc is not None
+    assert nfc.derived is not None
+    assert nfc.derived.op == "subtract"
+    assert nfc.feature_indices == (
+        obs.index("non_shiftable_load"),
+        obs.index("solar_generation"),
+    )
+    assert nfc.derived.left_index_in_segment == 0
+    assert nfc.derived.right_index_in_segment == 1
+
+
+def test_nfc_source_features_not_in_any_sro_group(builder_and_obs):
+    _, _, layout = builder_and_obs
+    for s in layout.segments:
+        if s.family == "sro":
+            assert "non_shiftable_load" not in s.feature_names
+            assert "solar_generation" not in s.feature_names
+
+
+# ---------------------------------------------------------------------------
+# ---
+# ---------------------------------------------------------------------------
+
+
+def test_excluded_features_dropped_before_classification(builder_and_obs):
+    _, _, layout = builder_and_obs
+    assert "district__topology_version" in layout.excluded_feature_names
+    for s in layout.segments:
+        assert "district__topology_version" not in s.feature_names
+
+
+# ---------------------------------------------------------------------------
+# ---
+# ---------------------------------------------------------------------------
+
+
+def test_unmatched_feature_raises(cfg):
+    from algorithms.utils.entity_token_layout import EntityTokenLayoutBuilder
+
+    builder = EntityTokenLayoutBuilder(cfg)
+    obs = load_sample_observation_names_for_first_building() + [
+        "district__some_new_feature"
+    ]
+    with pytest.raises(ValueError, match="district__some_new_feature"):
+        builder.build(
+            "Building_1",
+            obs,
+            ["electrical_storage", "electric_vehicle_storage"],
+        )
+
+
+def test_ambiguous_pattern_raises():
+    from algorithms.utils.entity_token_layout import EntityTokenLayoutBuilder
+    from utils.entity_tokenizer_schema import EntityTokenizerConfig
+
+    raw = json.loads(
+        Path("configs/tokenizers/entity_default.json").read_text()
+    )
+    raw["sro_types"]["district_time_dup"] = {
+        "entity_table": "district",
+        "cardinality": "singleton",
+        "feature_patterns": ["^district__hour$"],
+        "input_dim_fallback": 1,
+    }
+    cfg = EntityTokenizerConfig.model_validate(raw)
+    builder = EntityTokenLayoutBuilder(cfg)
+    obs = load_sample_observation_names_for_first_building()
+    with pytest.raises(
+        ValueError,
+        match=r"district__hour.*(district_time|district_time_dup)",
+    ):
+        builder.build(
+            "Building_1",
+            obs,
+            ["electrical_storage", "electric_vehicle_storage"],
+        )
+
+
+def test_missing_nfc_source_raises(cfg):
+    from algorithms.utils.entity_token_layout import EntityTokenLayoutBuilder
+
+    builder = EntityTokenLayoutBuilder(cfg)
+    obs = ["non_shiftable_load"]  # solar_generation missing
+    with pytest.raises(ValueError, match="solar_generation"):
+        builder.build("X", obs, [])
+
+
+def test_ca_count_mismatch_raises(cfg):
+    from algorithms.utils.entity_token_layout import EntityTokenLayoutBuilder
+
+    builder = EntityTokenLayoutBuilder(cfg)
+    obs = load_sample_observation_names_for_first_building()
+    with pytest.raises(ValueError, match="CA count mismatch"):
+        builder.build("Building_1", obs, ["electrical_storage"])
+
+
+# ---------------------------------------------------------------------------
+# ---
+# ---------------------------------------------------------------------------
+
+
+def test_sro_segment_order_follows_config_declaration(builder_and_obs):
+    _, _, layout = builder_and_obs
+    sros = [s for s in layout.segments if s.family == "sro"]
+    declared = [
+        "district_time",
+        "district_weather_current",
+        "district_weather_forecast",
+        "district_carbon",
+        "district_pricing_current",
+        "district_pricing_forecast",
+        "district_community_energy",
+        "district_community_headroom",
+        "district_community_history",
+        "district_meta",
+        "building_storage_state",
+        "building_charging_phase_onehot",
+        "building_charging_headroom",
+        "building_charging_violation",
+        "building_energy_current",
+        "building_energy_history",
+        "building_meta",
+        "pv",
+        "ev_connected",
+        "ev_incoming",
+    ]
+
+    def first_occurrence(seq):
+        out, seen = [], set()
+        for x in seq:
+            if x not in seen:
+                out.append(x)
+                seen.add(x)
+        return out
+
+    seen_in_layout = first_occurrence(s.type_name for s in sros)
+    expected = [t for t in declared if t in seen_in_layout]
+    assert seen_in_layout == expected
+
+
+def test_per_asset_sro_segments_sorted_by_instance_id(builder_and_obs):
+    _, _, layout = builder_and_obs
+    for tname in ("pv", "ev_connected", "ev_incoming"):
+        segs = [
+            s
+            for s in layout.segments
+            if s.family == "sro" and s.type_name == tname
+        ]
+        if len(segs) > 1:
+            ids = [s.instance_id for s in segs]
+            assert ids == sorted(ids), f"{tname} ids not sorted: {ids}"
+
+
+def test_segment_overall_order(builder_and_obs):
+    _, _, layout = builder_and_obs
+    families = [s.family for s in layout.segments]
+    n_sro = layout.n_sro
+    assert families[:n_sro] == ["sro"] * n_sro
+    assert families[n_sro] == "nfc"
+    assert families[n_sro + 1 :] == ["ca"] * layout.n_ca
+
+
+# ---------------------------------------------------------------------------
+# ---
+# ---------------------------------------------------------------------------
+
+
+def test_topology_changed_when_names_differ(builder_and_obs):
+    builder, obs, _ = builder_and_obs
+    new_obs = list(obs) + ["charger::Building_1/charger_99::power_kw"]
+    assert (
+        builder.topology_changed(
+            "Building_1",
+            new_obs,
+            ["electrical_storage", "electric_vehicle_storage"],
+        )
+        is True
+    )
+
+
+def test_topology_unchanged_for_identical_names(builder_and_obs):
+    builder, obs, _ = builder_and_obs
+    assert (
+        builder.topology_changed(
+            "Building_1",
+            obs,
+            ["electrical_storage", "electric_vehicle_storage"],
+        )
+        is False
+    )
+
+
+def test_layout_is_cached(builder_and_obs):
+    builder, obs, layout = builder_and_obs
+    layout2 = builder.build(
+        "Building_1",
+        obs,
+        ["electrical_storage", "electric_vehicle_storage"],
+    )
+    assert layout2 is layout
+
+
+# ---------------------------------------------------------------------------
+# ---
+# ---------------------------------------------------------------------------
+
+
+def test_no_external_imports():
+    """``algorithms/utils/entity_token_layout.py`` must be portable: only
+    stdlib + typing + re. No torch / numpy / pydantic / algorithms.* /
+    utils.* imports at any depth."""
+    src = Path("algorithms/utils/entity_token_layout.py").read_text()
+    tree = ast.parse(src)
+    forbidden = ("torch", "numpy", "pydantic", "algorithms.", "utils.")
+    bad: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                if any(n.name.startswith(p) for p in forbidden):
+                    bad.append(n.name)
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if any(mod.startswith(p) for p in forbidden):
+                bad.append(mod)
+    assert not bad, f"forbidden imports in entity_token_layout.py: {bad}"
+
+
+def test_coverage_accounting_matches_spec(builder_and_obs):
+    """Expected feature counts per singleton SRO type for one building."""
+    _, _, layout = builder_and_obs
+    counts: dict[str, int] = {}
+    for s in layout.segments:
+        if s.family == "sro" and s.instance_id == "Building_1":
+            counts[s.type_name] = (
+                counts.get(s.type_name, 0) + len(s.feature_indices)
+            )
+    expected = {
+        "district_time": 3,
+        "district_weather_current": 4,
+        "district_weather_forecast": 12,
+        "district_carbon": 1,
+        "district_pricing_current": 1,
+        "district_pricing_forecast": 3,
+        "district_community_energy": 12,
+        "district_community_headroom": 4,
+        "district_community_history": 2,
+        "district_meta": 3,
+        "building_storage_state": 2,
+        "building_charging_phase_onehot": 6,
+        "building_charging_headroom": 8,
+        "building_charging_violation": 1,
+        "building_energy_current": 15,
+        "building_energy_history": 4,
+    }
+    for k, v in expected.items():
+        assert counts.get(k) == v, (
+            f"{k}: expected {v} features, got {counts.get(k)}"
+        )

--- a/tests/test_entity_token_layout.py
+++ b/tests/test_entity_token_layout.py
@@ -106,10 +106,6 @@ def test_uses_real_sample_payload(builder_and_obs):
     )
 
 
-# ---------------------------------------------------------------------------
-# ---
-# ---------------------------------------------------------------------------
-
 
 def test_classifies_district_time_to_sro_singleton(builder_and_obs):
     _, obs, layout = builder_and_obs
@@ -218,10 +214,6 @@ def test_classifies_charger_prefix_to_ca(builder_and_obs):
             assert "::incoming_ev::" not in n
 
 
-# ---------------------------------------------------------------------------
-# ---
-# ---------------------------------------------------------------------------
-
 
 def test_nfc_segment_has_two_source_indices_and_subtract_op(builder_and_obs):
     _, obs, layout = builder_and_obs
@@ -245,10 +237,6 @@ def test_nfc_source_features_not_in_any_sro_group(builder_and_obs):
             assert "solar_generation" not in s.feature_names
 
 
-# ---------------------------------------------------------------------------
-# ---
-# ---------------------------------------------------------------------------
-
 
 def test_excluded_features_dropped_before_classification(builder_and_obs):
     _, _, layout = builder_and_obs
@@ -256,10 +244,6 @@ def test_excluded_features_dropped_before_classification(builder_and_obs):
     for s in layout.segments:
         assert "district__topology_version" not in s.feature_names
 
-
-# ---------------------------------------------------------------------------
-# ---
-# ---------------------------------------------------------------------------
 
 
 def test_unmatched_feature_raises(cfg):
@@ -322,10 +306,6 @@ def test_ca_count_mismatch_raises(cfg):
         builder.build("Building_1", obs, ["electrical_storage"])
 
 
-# ---------------------------------------------------------------------------
-# ---
-# ---------------------------------------------------------------------------
-
 
 def test_sro_segment_order_follows_config_declaration(builder_and_obs):
     _, _, layout = builder_and_obs
@@ -387,37 +367,6 @@ def test_segment_overall_order(builder_and_obs):
     assert families[n_sro] == "nfc"
     assert families[n_sro + 1 :] == ["ca"] * layout.n_ca
 
-
-# ---------------------------------------------------------------------------
-# ---
-# ---------------------------------------------------------------------------
-
-
-def test_topology_changed_when_names_differ(builder_and_obs):
-    builder, obs, _ = builder_and_obs
-    new_obs = list(obs) + ["charger::Building_1/charger_99::power_kw"]
-    assert (
-        builder.topology_changed(
-            "Building_1",
-            new_obs,
-            ["electrical_storage", "electric_vehicle_storage"],
-        )
-        is True
-    )
-
-
-def test_topology_unchanged_for_identical_names(builder_and_obs):
-    builder, obs, _ = builder_and_obs
-    assert (
-        builder.topology_changed(
-            "Building_1",
-            obs,
-            ["electrical_storage", "electric_vehicle_storage"],
-        )
-        is False
-    )
-
-
 def test_layout_is_cached(builder_and_obs):
     builder, obs, layout = builder_and_obs
     layout2 = builder.build(
@@ -427,10 +376,6 @@ def test_layout_is_cached(builder_and_obs):
     )
     assert layout2 is layout
 
-
-# ---------------------------------------------------------------------------
-# ---
-# ---------------------------------------------------------------------------
 
 
 def test_no_external_imports():

--- a/tests/test_entity_tokenizer_config_schema.py
+++ b/tests/test_entity_tokenizer_config_schema.py
@@ -283,4 +283,22 @@ def test_excluded_pattern_matches_topology_version():
     )
     assert not any(p.fullmatch("district__hour") for p in matchers)
 
+def test_excluded_feature_pattern_removes_topology_version():
+    """The exclusion regex removes the ``topology_version`` feature."""
+    from algorithms.utils.entity_token_layout import EntityTokenLayoutBuilder
+    from tests._entity_sample_obs_names import (
+        load_sample_observation_names_for_first_building,
+    )
+    from utils.entity_tokenizer_schema import load_entity_tokenizer_config
+
+    cfg = load_entity_tokenizer_config(
+        "configs/tokenizers/entity_default.json"
+    )
+    builder = EntityTokenLayoutBuilder(cfg)
+    layout = builder.build(
+        "Building_1",
+        load_sample_observation_names_for_first_building(),
+        ["electrical_storage", "electric_vehicle_storage"],
+    )
+    assert "district__topology_version" in layout.excluded_feature_names
 

--- a/tests/test_entity_tokenizer_config_schema.py
+++ b/tests/test_entity_tokenizer_config_schema.py
@@ -283,6 +283,7 @@ def test_excluded_pattern_matches_topology_version():
     )
     assert not any(p.fullmatch("district__hour") for p in matchers)
 
+
 def test_excluded_feature_pattern_removes_topology_version():
     """The exclusion regex removes the ``topology_version`` feature."""
     from algorithms.utils.entity_token_layout import EntityTokenLayoutBuilder


### PR DESCRIPTION
## What

Per-building token segmentation. Consumes the wrapper's
`(observation_names, action_names)` plus the tokenizer config from
WP06-01 and returns a deterministic `BuildingTokenLayout` (ordered
SROs, single NFC, CAs permuted to match `action_names` position-by-position).

**Stdlib + `typing` + `re` only** — no torch / numpy / pydantic /
`algorithms.*` / `utils.*` imports — portable to the inference repo
as-is.

## Files (3 / +916 / 0)

- `algorithms/utils/entity_token_layout.py` (472)
- `tests/test_entity_token_layout.py` (431)
- `tests/test_entity_tokenizer_config_schema.py` (+13, one cross-layer
  test deferred from WP06-01)

## What to review

1. **CA ordering invariant** — `ca_action_names == tuple(action_names[building])`
   element-by-element, enforced at construction. `_order_cas_by_action_names`
   handles unsuffixed (`electrical_storage`) and CityLearn-suffixed
   (`electric_vehicle_storage_charger_1_1`) names with deterministic
   fallback; longest matching prefix wins on ambiguity.
2. **SRO uniqueness at runtime** — `_classify_one` raises on ambiguous
   singleton SRO matches (runtime mirror of WP06-01 rule 2).
3. **NFC sources are consumed before SRO classification** so they cannot
   double-count into an SRO group.
4. **Portability assertion** — `test_no_external_imports` AST-checks
   zero forbidden imports. Do not introduce torch/pydantic here.
5. **Non-contiguous segments** — `feature_indices` is a tuple of
   absolute observation positions and may be non-contiguous; the
   torch tokenizer in WP06-03 slices via `index_select`.
