### PR TITLE
Add AgentTransformerPPO with dynamic topology support and cleanup

### DIFF
--- a/algorithms/agents/agent_transformer_ppo.py
+++ b/algorithms/agents/agent_transformer_ppo.py
@@ -1,0 +1,951 @@
+"""AgentTransformerPPO — per-building Transformer + PPO over the entity interface.
+
+Architecture (one stack per building, indexed by ``building_idx``):
+    encoded_obs ─► EntityObservationTokenizer ─► (sros, nfc, cas)
+                                            └─► TransformerBackbone ─► (ca_emb, pooled)
+                                                                    └─► ActorHead  ─► action
+                                                                    └─► CriticHead ─► V(s)
+
+Topology mutation: the wrapper's ``_apply_entity_layout`` calls
+``attach_environment(...)`` after every reset/step that increments the
+topology version. ``attach_environment`` is idempotent: it caches the
+``(observation_names, action_names)`` tuple per building and detects a
+topology change by comparing those tuples. On detection it
+(1) flushes the in-flight rollout buffer with a final PPO step,
+(2) rebuilds the layout via the cached ``EntityTokenLayoutBuilder``,
+(3) re-runs the hard-fail tokenizer rules against the new names,
+(4) rejects feature-count drift on existing types (would invalidate weights).
+
+Checkpoint resume across topology changes is out of scope —
+``load_checkpoint`` rejects on ``layout_signature`` mismatch.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json as _json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, ClassVar, Dict, List, Optional, Tuple
+
+import numpy as np
+import numpy.typing as npt
+import torch
+from loguru import logger
+from torch import nn
+
+from algorithms.agents.base_agent import BaseAgent
+from algorithms.utils.entity_observation_tokenizer import (
+    EntityObservationTokenizer,
+)
+from algorithms.utils.entity_token_layout import (
+    BuildingTokenLayout,
+    EntityTokenLayoutBuilder,
+)
+from algorithms.utils.ppo_components import (
+    ActorHead,
+    CriticHead,
+    RolloutBuffer,
+    compute_ppo_loss,
+)
+from algorithms.utils.transformer_backbone import TransformerBackbone
+from utils.entity_tokenizer_schema import (
+    EntityPayloadSample,
+    EntityTokenizerConfig,
+    load_entity_tokenizer_config,
+    validate_against_payload,
+)
+
+
+_SRO_PREFIX_RE = ("storage::", "charger::", "pv::")
+
+
+@dataclass
+class _PerBuildingState:
+    """All learning state owned by one building. Held in a list on the agent
+    indexed by ``building_idx``. The ``optimizer`` is rebuilt only when the
+    underlying parameter set changes (i.e. never within a stable topology)."""
+
+    building_id: str
+    tokenizer: EntityObservationTokenizer
+    backbone: TransformerBackbone
+    actor: ActorHead
+    critic: CriticHead
+    optimizer: torch.optim.Optimizer
+    buffer: RolloutBuffer
+    layout: BuildingTokenLayout
+    obs_names_tuple: Tuple[str, ...]
+    action_names_tuple: Tuple[str, ...]
+    entity_specs_signature: Optional[str] = None
+    # Per-building topology version. Starts at 0 on first attach and is
+    # incremented each time :meth:`_handle_topology_change` succeeds. The
+    # exporter records this in ``artifact_manifest.json`` so deployment
+    # callers can route to the right artifact bundle for a given mutation.
+    topology_version: int = 0
+
+
+def _atanh_safe(x: torch.Tensor, eps: float = 1.0e-6) -> torch.Tensor:
+    """Numerically-safe inverse tanh used to recover the pre-squash sample
+    from a stored ``[-1, 1]`` action."""
+    x = x.clamp(-1.0 + eps, 1.0 - eps)
+    return 0.5 * (torch.log1p(x) - torch.log1p(-x))
+
+
+class AgentTransformerPPO(BaseAgent):
+    """Per-building Transformer + PPO."""
+
+    supports_dynamic_topology: ClassVar[bool] = True
+
+    def __init__(self, config: Dict[str, Any]) -> None:
+        super().__init__()
+        self.config = config
+        algo = config["algorithm"]
+
+        self._tokenizer_config_path: str = str(algo["tokenizer_config_path"])
+        self._tokenizer_config: EntityTokenizerConfig = (
+            load_entity_tokenizer_config(self._tokenizer_config_path)
+        )
+
+        transformer_cfg = dict(algo["transformer"])
+        self._d_model = int(transformer_cfg["d_model"])
+        self._nhead = int(transformer_cfg["nhead"])
+        self._num_layers = int(transformer_cfg["num_layers"])
+        self._dim_feedforward = int(transformer_cfg.get("dim_feedforward", 256))
+        self._dropout = float(transformer_cfg.get("dropout", 0.1))
+
+        h = dict(algo["hyperparameters"])
+        self._lr = float(h["learning_rate"])
+        self._gamma = float(h["gamma"])
+        self._gae_lambda = float(h["gae_lambda"])
+        self._clip_eps = float(h["clip_eps"])
+        self._ppo_epochs = int(h["ppo_epochs"])
+        self._minibatch_size = int(h["minibatch_size"])
+        self._entropy_coeff = float(h.get("entropy_coeff", 0.0))
+        self._value_coeff = float(h.get("value_coeff", 0.5))
+        self._max_grad_norm = float(h.get("max_grad_norm", 0.5))
+        self._reward_clip = float(h.get("reward_clip", 10.0))  # clip rewards to [-clip, 0]
+        self._actor_hidden_dim = int(
+            h.get("actor_hidden_dim", max(32, self._d_model * 2))
+        )
+        self._critic_hidden_dim = int(
+            h.get("critic_hidden_dim", max(32, self._d_model * 2))
+        )
+
+        self._layout_builder = EntityTokenLayoutBuilder(self._tokenizer_config)
+        self._per_building: List[_PerBuildingState] = []
+
+        # Tracks whether ``attach_environment`` has ever been called. The
+        # very first call is not a topology change.
+        self._first_attach_done = False
+
+    # ==========================================================================
+    # BaseAgent contract
+    # ==========================================================================
+
+    def attach_environment(  # type: ignore[override]
+        self,
+        *,
+        observation_names: List[List[str]],
+        action_names: List[List[str]],
+        action_space: List[Any],
+        observation_space: List[Any],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Build (or rebuild) per-building stacks. Idempotent: identical
+        ``(observation_names, action_names)`` is a no-op. Detected mutation
+        triggers ``_handle_topology_change(building_idx)`` per affected
+        building."""
+        if not self._first_attach_done:
+            # First-ever attach — fresh build for every building.
+            self._build_all_per_building_states(
+                observation_names, action_names, metadata
+            )
+            self._first_attach_done = True
+            for st in self._per_building:
+                logger.info(
+                    "Initial attach: {} — obs_dim={}, n_sro={}, n_ca={}, "
+                    "actions={}",
+                    st.building_id,
+                    len(st.obs_names_tuple),
+                    st.layout.n_sro,
+                    st.layout.n_ca,
+                    list(st.action_names_tuple),
+                )
+            return
+
+        if len(self._per_building) != len(observation_names):
+            # Total building-count change is treated as a complete rebuild —
+            # cannot resume per-building states across cardinality changes.
+            self._per_building = []
+            self._build_all_per_building_states(
+                observation_names, action_names, metadata
+            )
+            return
+
+        for b, (obs_n, act_n) in enumerate(
+            zip(observation_names, action_names)
+        ):
+            new_obs = tuple(obs_n)
+            new_act = tuple(act_n)
+            state = self._per_building[b]
+            if (
+                state.obs_names_tuple == new_obs
+                and state.action_names_tuple == new_act
+            ):
+                # No change for this building.
+                continue
+            # Stash new names then run the topology transition
+            # (flush PPO → rebuild layout → re-validate rules).
+            state.obs_names_tuple = new_obs
+            state.action_names_tuple = new_act
+            state.entity_specs_signature = self._signature(metadata)
+            self._handle_topology_change(b)
+
+    def predict(
+        self,
+        observations: List[npt.NDArray[np.float64]],
+        deterministic: bool | None = None,
+        *,
+        context: Any = None,
+    ) -> List[List[float]]:
+        det = bool(deterministic) if deterministic is not None else False
+        out: List[List[float]] = []
+        for state, obs in zip(self._per_building, observations):
+            obs_t = torch.as_tensor(np.asarray(obs), dtype=torch.float).unsqueeze(0)
+            with torch.no_grad():
+                tokenized = state.tokenizer(obs_t, state.layout)
+                ca_emb, _ = state.backbone(
+                    tokenized.sro_tokens,
+                    tokenized.nfc_token,
+                    tokenized.ca_tokens,
+                )
+                actions, _, _ = state.actor(ca_emb, deterministic=det)
+            # ActorHead returns ``[B, N_ca, 1]``; the wrapper expects a flat
+            # per-CA list.
+            out.append(actions.squeeze(0).squeeze(-1).clamp(-1.0, 1.0).tolist())
+        return out
+
+    def update(
+        self,
+        observations: List[npt.NDArray[np.float64]],
+        actions: List[npt.NDArray[np.float64]],
+        rewards: List[float],
+        next_observations: List[npt.NDArray[np.float64]],
+        terminated: bool,
+        truncated: bool,
+        *,
+        update_target_step: bool,
+        global_learning_step: int,
+        update_step: bool,
+        initial_exploration_done: bool,
+    ) -> None:
+        """Append the transition to each per-building rollout buffer; when
+        ``update_step`` is true, run a PPO update per building and clear."""
+        del update_target_step, global_learning_step, initial_exploration_done
+
+        done = bool(terminated or truncated)
+        for b, state in enumerate(self._per_building):
+            obs_t = torch.as_tensor(
+                np.asarray(observations[b]), dtype=torch.float
+            ).unsqueeze(0)
+            act_t = torch.as_tensor(
+                np.asarray(actions[b]), dtype=torch.float
+            )
+            # Reshape actions to ``[1, N_ca, 1]`` to match ActorHead output.
+            act_t = act_t.view(1, state.layout.n_ca, 1)
+            with torch.no_grad():
+                tokenized = state.tokenizer(obs_t, state.layout)
+                ca_emb, pooled = state.backbone(
+                    tokenized.sro_tokens,
+                    tokenized.nfc_token,
+                    tokenized.ca_tokens,
+                )
+                value = state.critic(pooled).squeeze(-1)  # [1]
+                log_prob = self._compute_log_prob(state.actor, ca_emb, act_t)
+            state.buffer.add(
+                observation=obs_t.squeeze(0),
+                action=act_t.squeeze(0),
+                log_prob=log_prob.squeeze(0),
+                reward=max(float(rewards[b]), -self._reward_clip),
+                value=value,
+                done=done,
+            )
+
+        if not update_step:
+            return
+
+        for state in self._per_building:
+            self._ppo_update(state, next_observations)
+            state.buffer.clear()
+
+    def export_artifacts(  # type: ignore[override]
+        self,
+        output_dir: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Write per-building ONNX artefacts + return manifest metadata.
+
+        Filename pattern: ``agent_<b>__topology_v<v>.onnx``. Per-building
+        entry includes ``agent_index``, ``path``, ``format``, and a
+        ``config`` block carrying the layout summary needed by the
+        deployment side."""
+        out = Path(output_dir)
+        models_dir = out / "onnx_models"
+        models_dir.mkdir(parents=True, exist_ok=True)
+
+        # Per-building topology version: explicit override via context wins
+        # (preserves backward compat with callers that pass it), else use
+        # the per-building counter maintained by ``_handle_topology_change``.
+        ctx_version = (context or {}).get("topology_version")
+        artifacts: List[Dict[str, Any]] = []
+        agent_models: List[Dict[str, Any]] = []
+        for b, state in enumerate(self._per_building):
+            topology_version = (
+                int(ctx_version) if ctx_version is not None
+                else int(state.topology_version)
+            )
+            obs_dim = self._infer_obs_dim(state.layout)
+            relpath = (
+                f"onnx_models/agent_{b}__topology_v{topology_version}.onnx"
+            )
+            self._export_onnx(state, out / relpath, obs_dim)
+            sro_types = [
+                s.type_name for s in state.layout.segments if s.family == "sro"
+            ]
+            ca_types = [
+                s.type_name for s in state.layout.segments if s.family == "ca"
+            ]
+            cfg = {
+                "building_id": state.building_id,
+                "topology_version": topology_version,
+                "obs_dim": obs_dim,
+                "n_sro": state.layout.n_sro,
+                "n_ca": state.layout.n_ca,
+                "sro_types": sro_types,
+                "ca_types": ca_types,
+                "ca_action_names": list(state.layout.ca_action_names),
+            }
+            artifacts.append(
+                {
+                    "agent_index": b,
+                    "path": relpath,
+                    "format": "onnx",
+                    "config": cfg,
+                }
+            )
+            agent_models.append(
+                {
+                    "building_index": b,
+                    "building_id": state.building_id,
+                    "topology_version": topology_version,
+                    "model_path": relpath,
+                    **{
+                        k: cfg[k]
+                        for k in (
+                            "obs_dim",
+                            "n_sro",
+                            "n_ca",
+                            "sro_types",
+                            "ca_types",
+                            "ca_action_names",
+                        )
+                    },
+                }
+            )
+        return {
+            "format": "onnx",
+            "artifacts": artifacts,
+            "tokenizer_config_path": self._tokenizer_config_path,
+            "supports_dynamic_topology": True,
+            "agent_models": agent_models,
+        }
+
+    def save_checkpoint(self, output_dir: str, step: int) -> Optional[str]:
+        out = Path(output_dir) / "checkpoints"
+        out.mkdir(parents=True, exist_ok=True)
+        path = out / f"transformer_ppo_step{step}.pt"
+        payload = {
+            "step": int(step),
+            "config": dict(self.config["algorithm"]),
+            "agents": [
+                {
+                    "building_id": s.building_id,
+                    "tokenizer_state": s.tokenizer.state_dict(),
+                    "backbone_state": s.backbone.state_dict(),
+                    "actor_state": s.actor.state_dict(),
+                    "critic_state": s.critic.state_dict(),
+                    "optimizer_state": s.optimizer.state_dict(),
+                    "layout_signature": tuple(sorted(s.obs_names_tuple)),
+                    "action_names": list(s.action_names_tuple),
+                }
+                for s in self._per_building
+            ],
+        }
+        torch.save(payload, path)
+        return str(path)
+
+    def load_checkpoint(self, checkpoint_path: str) -> None:
+        payload = torch.load(checkpoint_path, map_location="cpu")
+        agents = payload["agents"]
+        if len(agents) != len(self._per_building):
+            raise ValueError(
+                f"Checkpoint has {len(agents)} per-building entries; current "
+                f"agent has {len(self._per_building)}. Cross-cardinality "
+                "resume is not supported."
+            )
+        for state, saved in zip(self._per_building, agents):
+            sig_now = tuple(sorted(state.obs_names_tuple))
+            sig_saved = tuple(saved["layout_signature"])
+            if sig_now != sig_saved:
+                raise ValueError(
+                    "Checkpoint layout_signature mismatch for building "
+                    f"{state.building_id!r}: cannot resume across topology "
+                    "changes."
+                )
+            state.tokenizer.load_state_dict(saved["tokenizer_state"])
+            state.backbone.load_state_dict(saved["backbone_state"])
+            state.actor.load_state_dict(saved["actor_state"])
+            state.critic.load_state_dict(saved["critic_state"])
+            state.optimizer.load_state_dict(saved["optimizer_state"])
+
+    # ==========================================================================
+    # Internal helpers
+    # ==========================================================================
+
+    def _build_all_per_building_states(
+        self,
+        observation_names: List[List[str]],
+        action_names: List[List[str]],
+        metadata: Optional[Dict[str, Any]],
+    ) -> None:
+        sig = self._signature(metadata)
+        building_names = (
+            (metadata or {}).get("building_names")
+            if metadata is not None
+            else None
+        )
+        for b, (obs_n, act_n) in enumerate(
+            zip(observation_names, action_names)
+        ):
+            building_id = (
+                building_names[b]
+                if building_names and b < len(building_names) and building_names[b]
+                else f"building_{b}"
+            )
+            state = self._build_one_per_building_state(
+                building_id, list(obs_n), list(act_n), sig
+            )
+            self._per_building.append(state)
+
+    def _build_one_per_building_state(
+        self,
+        building_id: str,
+        observation_names: List[str],
+        action_names: List[str],
+        entity_specs_signature: Optional[str],
+    ) -> _PerBuildingState:
+        layout = self._layout_builder.build(
+            building_id, observation_names, action_names
+        )
+        # post-condition: CA order matches simulator action order.
+        # Match is exact OR ``action_field`` is a prefix of the simulator
+        # action name (CityLearn appends a charger-id suffix when multiple
+        # CAs of the same type are present, e.g.
+        # ``electric_vehicle_storage_charger_1_1``).
+        for af, an in zip(layout.ca_action_names, action_names):
+            if an == af or an.startswith(af + "_"):
+                continue
+            raise ValueError(
+                f"BuildingTokenLayout.ca_action_names "
+                f"{layout.ca_action_names!r} does not match action_names "
+                f"{tuple(action_names)!r} for building {building_id!r}."
+            )
+        type_input_dims = self._compute_type_input_dims(layout)
+        tokenizer = EntityObservationTokenizer(
+            tokenizer_config=self._tokenizer_config,
+            d_model=self._d_model,
+            type_input_dims=type_input_dims,
+        )
+        backbone = TransformerBackbone(
+            d_model=self._d_model,
+            nhead=self._nhead,
+            num_layers=self._num_layers,
+            dim_feedforward=self._dim_feedforward,
+            dropout=self._dropout,
+        )
+        actor = ActorHead(d_model=self._d_model, hidden_dim=self._actor_hidden_dim)
+        critic = CriticHead(
+            d_model=self._d_model, hidden_dim=self._critic_hidden_dim
+        )
+        params = (
+            list(tokenizer.parameters())
+            + list(backbone.parameters())
+            + list(actor.parameters())
+            + list(critic.parameters())
+        )
+        optimizer = torch.optim.Adam(params, lr=self._lr)
+        buffer = RolloutBuffer(gamma=self._gamma, gae_lambda=self._gae_lambda)
+        return _PerBuildingState(
+            building_id=building_id,
+            tokenizer=tokenizer,
+            backbone=backbone,
+            actor=actor,
+            critic=critic,
+            optimizer=optimizer,
+            buffer=buffer,
+            layout=layout,
+            obs_names_tuple=tuple(observation_names),
+            action_names_tuple=tuple(action_names),
+            entity_specs_signature=entity_specs_signature,
+        )
+
+    def _handle_topology_change(self, building_idx: int) -> None:
+        """Flush PPO → rebuild layout → re-validate rules."""
+        state = self._per_building[building_idx]
+
+        old_n_ca = state.layout.n_ca
+        old_n_sro = state.layout.n_sro
+        old_actions = list(state.layout.ca_action_names)
+        old_obs_dim = len(state.layout.segments)
+
+        # 1. Flush in-flight rollout (best-effort) before discarding the old
+        #    layout. ``_ppo_update`` swallows empty-buffer no-ops.
+        if len(state.buffer) > 0:
+            try:
+                # Use a zero "next value" — last transition is treated as
+                # terminal because the topology under it is gone. This is
+                # the conservative choice; a future improvement could
+                # forward through the new layout's critic.
+                self._run_ppo_update_with_last_value(
+                    state, last_value=torch.zeros(1)
+                )
+            finally:
+                state.buffer.clear()
+
+        # 2. Rebuild the layout from the cached ``names``.
+        new_layout = self._layout_builder.build(
+            state.building_id,
+            list(state.obs_names_tuple),
+            list(state.action_names_tuple),
+        )
+
+        # 3. Re-run the hard-fail rules against a synthetic single-table
+        #    sample reconstructed from the current observation_names.
+        synthetic_sample = _synthetic_sample_from_obs_names(
+            list(state.obs_names_tuple)
+        )
+        validate_against_payload(
+            self._tokenizer_config,
+            synthetic_sample,
+            [list(state.action_names_tuple)],
+            # Rule 5 (action-field coverage) is a startup-only sanity check
+            # against the simulator schema. After a runtime topology
+            # mutation the set of active assets may legitimately become a
+            # strict subset of the configured CA types (e.g. last EV
+            # charger was removed); skipping it avoids false positives.
+            include_rule_5=False,
+        )
+
+        # 4. Reject feature-count drift on existing types — would invalidate
+        #    learned weights. New instances of an existing type are fine
+        #    (per-type weight sharing); a different feature COUNT for a type
+        #    that already has weights is a hard fail.
+        new_dims = self._compute_type_input_dims(new_layout)
+        for tname, dim in new_dims.items():
+            if tname not in state.tokenizer.projections:
+                # New type appearing — that's an unrecoverable schema change.
+                raise ValueError(
+                    f"Topology change for building {state.building_id!r}: "
+                    f"new type {tname!r} appeared in layout; current "
+                    "tokenizer has no projection for it. Restart from "
+                    "scratch with a tokenizer config that declares this type."
+                )
+            existing_proj = state.tokenizer.projections[tname]
+            if int(existing_proj.in_features) != int(dim):
+                raise ValueError(
+                    f"Topology change for building {state.building_id!r}: "
+                    f"feature count for type {tname!r} changed "
+                    f"{existing_proj.in_features} -> {dim}; weights cannot "
+                    "be preserved across feature-schema changes."
+                )
+
+        # 5. Replace the layout. Per-building NN weights and optimizer state
+        #    are preserved (per-type weight sharing).
+        state.layout = new_layout
+        state.topology_version += 1
+
+        logger.info(
+            "Topology change: {} v{} — "
+            "n_ca: {} → {}, n_sro: {} → {}, "
+            "actions: {} → {}",
+            state.building_id,
+            state.topology_version,
+            old_n_ca,
+            new_layout.n_ca,
+            old_n_sro,
+            new_layout.n_sro,
+            old_actions,
+            list(new_layout.ca_action_names),
+        )
+
+        # 6. post-condition. Mirror the startup-side prefix
+        #    tolerance from :meth:`_build_one_per_building_state`: CityLearn
+        #    suffixes ``electric_vehicle_storage_<charger_id>`` when there
+        #    are multiple chargers, so we accept exact match OR
+        #    ``action_field`` being a prefix of the simulator action name.
+        if len(state.layout.ca_action_names) != len(state.action_names_tuple):
+            raise ValueError(
+                "Post-rebuild CA order mismatch for building "
+                f"{state.building_id!r}: layout has "
+                f"{state.layout.ca_action_names!r}, action_names "
+                f"{state.action_names_tuple!r}"
+            )
+        for af, an in zip(state.layout.ca_action_names, state.action_names_tuple):
+            if an == af or an.startswith(af + "_"):
+                continue
+            raise ValueError(
+                "Post-rebuild CA order mismatch for building "
+                f"{state.building_id!r}: layout has "
+                f"{state.layout.ca_action_names!r}, action_names "
+                f"{state.action_names_tuple!r}"
+            )
+
+    def _compute_type_input_dims(
+        self, layout: BuildingTokenLayout
+    ) -> Dict[str, int]:
+        """Per-type input dim derived from segment widths.
+
+        NFC is hard-coded to 1. Declared types absent from the layout get a
+        placeholder dim equal to their declared ``input_dim_fallback`` so
+        the per-type projection is sized correctly from the start. This
+        matters under dynamic topology: when a previously-empty type later
+        gains its first instance (e.g. a topology event adds the first EV
+        charger to a building), the new segment width will equal the
+        fallback and the existing projection will accept it without the
+        feature-count-drift fail-fast in :meth:`_handle_topology_change`.
+
+        If the placeholder were always 1, any later real instance with
+        ``input_dim_fallback > 1`` would force a hard failure, even though
+        no learning has yet happened on that type's weights.
+        """
+        nfc_name = self._tokenizer_config.nfc.type_name
+        dims: Dict[str, int] = {nfc_name: 1}
+        for seg in layout.segments:
+            if seg.family == "nfc":
+                continue
+            existing = dims.get(seg.type_name)
+            new = len(seg.feature_indices)
+            if existing is not None and existing != new:
+                raise ValueError(
+                    f"Inconsistent input dim for type {seg.type_name!r}: "
+                    f"{existing} vs {new}"
+                )
+            dims[seg.type_name] = new
+        for tname, ca_cfg in self._tokenizer_config.ca_types.items():
+            dims.setdefault(tname, int(ca_cfg.input_dim_fallback))
+        for tname, sro_cfg in self._tokenizer_config.sro_types.items():
+            dims.setdefault(tname, int(sro_cfg.input_dim_fallback))
+        return dims
+
+    @staticmethod
+    def _signature(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+        if not metadata or "entity_specs" not in metadata or not metadata["entity_specs"]:
+            return None
+        s = _json.dumps(metadata["entity_specs"], sort_keys=True, default=str)
+        return hashlib.sha256(s.encode()).hexdigest()[:16]
+
+    @staticmethod
+    def _infer_obs_dim(layout: BuildingTokenLayout) -> int:
+        return max(max(seg.feature_indices) for seg in layout.segments) + 1
+
+    # ----- PPO loss helpers ---------------------------------------------------
+
+    @staticmethod
+    def _compute_log_prob(
+        actor: ActorHead,
+        ca_embeddings: torch.Tensor,  # [B, N_ca, d_model]
+        actions_tanh: torch.Tensor,  # [B, N_ca, 1] in [-1, 1]
+    ) -> torch.Tensor:
+        """Compute log-prob of a stored squashed action under the actor's
+        current Normal(mean, std)+tanh distribution. Returns ``[B, N_ca]``.
+        """
+        means = actor.mlp(ca_embeddings)  # [B, N_ca, 1]
+        log_std_clamped = torch.clamp(actor.log_std, min=-2.0, max=0.5)
+        std = torch.exp(log_std_clamped).expand_as(means)
+        pre_tanh = _atanh_safe(actions_tanh)
+        # log p(pre_tanh) - log(1 - tanh(pre_tanh)^2)
+        normal = torch.distributions.Normal(means, std)
+        log_prob_pre = normal.log_prob(pre_tanh)
+        log_prob = log_prob_pre - torch.log(
+            1.0 - actions_tanh.pow(2) + 1.0e-6
+        )
+        return log_prob.squeeze(-1)
+
+    def _ppo_update(
+        self,
+        state: _PerBuildingState,
+        next_observations: List[npt.NDArray[np.float64]],
+    ) -> None:
+        if len(state.buffer) == 0:
+            return
+        # Defensive guard: PPO is on-policy and needs a meaningful trajectory
+        # batch before updating. If the wrapper's `update_step` cadence
+        # (`simulator.steps_between_training_updates`) is set too low, the
+        # buffer can be smaller than a single minibatch which produces a
+        # degenerate update (zero-mean advantages, NaN-prone log_prob
+        # gradients on near-saturated stored actions). Skip with a warning.
+        if len(state.buffer) < self._minibatch_size:
+            logger.warning(
+                "Skipping PPO update for {}: buffer_size={} < minibatch_size={}. "
+                "Increase `simulator.steps_between_training_updates` (recommended >= 256) "
+                "to give PPO a real trajectory to learn from.",
+                getattr(state, "building_id", "?"),
+                len(state.buffer),
+                self._minibatch_size,
+            )
+            return
+        # Bootstrap value from the next observation of this building.
+        try:
+            b_idx = self._per_building.index(state)
+            next_obs = next_observations[b_idx]
+        except (ValueError, IndexError):
+            next_obs = None
+        if next_obs is None:
+            last_value = torch.zeros(1)
+        else:
+            last_value = self._critic_value(
+                state, np.asarray(next_obs, dtype=np.float64)
+            )
+        self._run_ppo_update_with_last_value(state, last_value)
+
+    def _critic_value(
+        self,
+        state: _PerBuildingState,
+        obs: npt.NDArray[np.float64],
+    ) -> torch.Tensor:
+        with torch.no_grad():
+            obs_t = torch.as_tensor(obs, dtype=torch.float).unsqueeze(0)
+            tokenized = state.tokenizer(obs_t, state.layout)
+            _, pooled = state.backbone(
+                tokenized.sro_tokens, tokenized.nfc_token, tokenized.ca_tokens
+            )
+            return state.critic(pooled).squeeze(-1)
+
+    def _run_ppo_update_with_last_value(
+        self, state: _PerBuildingState, last_value: torch.Tensor
+    ) -> None:
+        state.buffer.compute_returns_and_advantages(last_value)
+        all_metrics: dict = {"policy_loss": [], "value_loss": [], "entropy": []}
+        for _epoch in range(self._ppo_epochs):
+            for batch in state.buffer.get_batches(self._minibatch_size):
+                state.optimizer.zero_grad()
+                obs_b = batch.observations  # [B, obs_dim]
+                act_b = batch.actions  # [B, N_ca, 1]
+                # Forward through tokenizer + backbone with grads on.
+                tokenized = state.tokenizer(obs_b, state.layout)
+                ca_emb, pooled = state.backbone(
+                    tokenized.sro_tokens,
+                    tokenized.nfc_token,
+                    tokenized.ca_tokens,
+                )
+                log_probs_new = self._compute_log_prob(
+                    state.actor, ca_emb, act_b
+                )  # [B, N_ca]
+                # Sum over CA actions per step → scalar per step (matches
+                # log_probs_old shape stored in buffer).
+                log_probs_new_sum = log_probs_new.sum(dim=-1)
+                log_probs_old_sum = batch.log_probs.sum(dim=-1)
+                values = state.critic(pooled).squeeze(-1)  # [B]
+                loss, _metrics = compute_ppo_loss(
+                    log_probs_new=log_probs_new_sum,
+                    log_probs_old=log_probs_old_sum,
+                    advantages=batch.advantages,
+                    values=values,
+                    returns=batch.returns,
+                    clip_eps=self._clip_eps,
+                    value_coeff=self._value_coeff,
+                    entropy_coeff=self._entropy_coeff,
+                )
+                loss.backward()
+                torch.nn.utils.clip_grad_norm_(
+                    list(state.tokenizer.parameters())
+                    + list(state.backbone.parameters())
+                    + list(state.actor.parameters())
+                    + list(state.critic.parameters()),
+                    self._max_grad_norm,
+                )
+                state.optimizer.step()
+                for k, v in _metrics.items():
+                    all_metrics.setdefault(k, []).append(v)
+        averaged = {k: sum(v) / len(v) for k, v in all_metrics.items() if v}
+        building_id = getattr(state, "building_id", "?")
+        logger.info(
+            "PPO update [{}]: policy_loss={:.4f}, value_loss={:.4f}, entropy={:.4f}, clip_frac={:.3f}",
+            building_id,
+            averaged.get("policy_loss", 0.0),
+            averaged.get("value_loss", 0.0),
+            averaged.get("entropy", 0.0),
+            averaged.get("clip_fraction", 0.0),
+        )
+
+    # ----- ONNX export --------------------------------------------------------
+
+    def _export_onnx(
+        self,
+        state: _PerBuildingState,
+        path: Path,
+        obs_dim: int,
+    ) -> None:
+        """Save the actor pipeline as ONNX. The layout indices are baked
+        into the wrapper as Python constants. Pure ``index_select`` +
+        Linear + Transformer + ActorHead → traceable."""
+        layout = state.layout
+        sros_idx_per_seg = [
+            torch.tensor(list(seg.feature_indices), dtype=torch.long)
+            for seg in layout.segments
+            if seg.family == "sro"
+        ]
+        ca_idx_per_seg = [
+            torch.tensor(list(seg.feature_indices), dtype=torch.long)
+            for seg in layout.segments
+            if seg.family == "ca"
+        ]
+        nfc_seg = next(s for s in layout.segments if s.family == "nfc")
+        nfc_idx = torch.tensor(
+            list(nfc_seg.feature_indices), dtype=torch.long
+        )
+        nfc_l = nfc_seg.derived.left_index_in_segment
+        nfc_r = nfc_seg.derived.right_index_in_segment
+
+        sro_types = [s.type_name for s in layout.segments if s.family == "sro"]
+        ca_types = [s.type_name for s in layout.segments if s.family == "ca"]
+
+        tokenizer = state.tokenizer
+        backbone = state.backbone
+        actor = state.actor
+
+        class _ExportWrapper(nn.Module):
+            def __init__(self_inner) -> None:
+                super().__init__()
+                self_inner.tokenizer = tokenizer
+                self_inner.backbone = backbone
+                self_inner.actor = actor
+
+            def forward(self_inner, encoded_obs: torch.Tensor) -> torch.Tensor:
+                sro_tokens_list = []
+                for seg_idx, idx in zip(range(len(sros_idx_per_seg)), sros_idx_per_seg):
+                    g = encoded_obs.index_select(dim=1, index=idx)
+                    proj = self_inner.tokenizer.projections[sro_types[seg_idx]]
+                    sro_tokens_list.append(proj(g).unsqueeze(1))
+                ca_tokens_list = []
+                for seg_idx, idx in zip(range(len(ca_idx_per_seg)), ca_idx_per_seg):
+                    g = encoded_obs.index_select(dim=1, index=idx)
+                    proj = self_inner.tokenizer.projections[ca_types[seg_idx]]
+                    ca_tokens_list.append(proj(g).unsqueeze(1))
+                nfc_grp = encoded_obs.index_select(dim=1, index=nfc_idx)
+                scalar = (nfc_grp[:, nfc_l] - nfc_grp[:, nfc_r]).unsqueeze(1)
+                nfc_tok = self_inner.tokenizer.projections[
+                    "building_nfc"
+                ](scalar).unsqueeze(1)
+                if sro_tokens_list:
+                    sros = torch.cat(sro_tokens_list, dim=1)
+                else:
+                    sros = encoded_obs.new_zeros(
+                        encoded_obs.shape[0], 0, self_inner.backbone.d_model
+                    )
+                if ca_tokens_list:
+                    cas = torch.cat(ca_tokens_list, dim=1)
+                else:
+                    cas = encoded_obs.new_zeros(
+                        encoded_obs.shape[0], 0, self_inner.backbone.d_model
+                    )
+                ca_emb, _ = self_inner.backbone(sros, nfc_tok, cas)
+                # ActorHead.forward returns (actions, log_probs, means);
+                # for export we want the deterministic mean ∈ [-1, 1].
+                means = self_inner.actor.mlp(ca_emb)
+                return torch.tanh(means).squeeze(-1)
+
+        wrapper = _ExportWrapper().eval()
+        dummy = torch.zeros(1, obs_dim)
+        with torch.no_grad():
+            # The legacy TorchScript-based ONNX exporter (default
+            # ``torch.onnx.export``) does not support PyTorch's fast-path
+            # ``aten::_transformer_encoder_layer_fwd`` operator. Disable the
+            # MHA fastpath for the duration of the trace so the standard
+            # decomposed encoder ops (matmul, softmax, etc.) are emitted.
+            try:
+                from torch.backends.mha import set_fastpath_enabled
+
+                _restore_to: Optional[bool] = True
+                set_fastpath_enabled(False)
+            except ImportError:  # pragma: no cover
+                _restore_to = None
+            try:
+                torch.onnx.export(
+                    wrapper,
+                    (dummy,),
+                    str(path),
+                    input_names=["encoded_obs"],
+                    output_names=["actions"],
+                    dynamic_axes={
+                        "encoded_obs": {0: "batch"},
+                        "actions": {0: "batch"},
+                    },
+                    opset_version=17,
+                )
+            finally:
+                if _restore_to is not None:
+                    from torch.backends.mha import set_fastpath_enabled
+
+                    set_fastpath_enabled(True)
+
+
+# ==========================================================================
+# Free helpers
+# ==========================================================================
+
+
+def _synthetic_sample_from_obs_names(
+    observation_names: List[str],
+) -> EntityPayloadSample:
+    """Reconstruct an ``EntityPayloadSample`` (per-table feature lists) from
+    the agent-level observation_names, so the validator can re-run its rules
+    at runtime after a topology change without needing the env.
+
+    Naming mirrors ``utils/entity_adapter.py``:
+
+    - ``district__<feat>``                         → ``district`` (prefix kept)
+    - ``storage::<id>::<feat>``                    → ``storage``
+    - ``pv::<id>::<feat>``                         → ``pv``
+    - ``charger::<id>::<feat>``                    → ``charger``
+    - ``charger::<id>::(connected_ev|incoming_ev)::<feat>`` → ``ev``
+    - everything else (no ``::`` and no ``district__``) → ``building``
+    """
+    by_table: Dict[str, set[str]] = {
+        "district": set(),
+        "building": set(),
+        "storage": set(),
+        "pv": set(),
+        "charger": set(),
+        "ev": set(),
+    }
+    for name in observation_names:
+        if name.startswith("district__"):
+            by_table["district"].add(name)
+            continue
+        if "::" in name:
+            head, *rest = name.split("::")
+            if head not in {"storage", "pv", "charger"}:
+                continue
+            if head == "charger" and len(rest) >= 3 and rest[1] in {
+                "connected_ev",
+                "incoming_ev",
+            }:
+                by_table["ev"].add(rest[2])
+            else:
+                by_table[head].add(rest[1] if len(rest) >= 2 else rest[0])
+            continue
+        by_table["building"].add(name)
+    return EntityPayloadSample(
+        feature_names_per_table={k: sorted(v) for k, v in by_table.items()}
+    )

--- a/algorithms/agents/agent_transformer_ppo.py
+++ b/algorithms/agents/agent_transformer_ppo.py
@@ -22,9 +22,7 @@ Checkpoint resume across topology changes is out of scope —
 
 from __future__ import annotations
 
-import hashlib
-import json as _json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Optional, Tuple
 
@@ -57,9 +55,6 @@ from utils.entity_tokenizer_schema import (
 )
 
 
-_SRO_PREFIX_RE = ("storage::", "charger::", "pv::")
-
-
 @dataclass
 class _PerBuildingState:
     """All learning state owned by one building. Held in a list on the agent
@@ -76,7 +71,6 @@ class _PerBuildingState:
     layout: BuildingTokenLayout
     obs_names_tuple: Tuple[str, ...]
     action_names_tuple: Tuple[str, ...]
-    entity_specs_signature: Optional[str] = None
     # Per-building topology version. Starts at 0 on first attach and is
     # incremented each time :meth:`_handle_topology_change` succeeds. The
     # exporter records this in ``artifact_manifest.json`` so deployment
@@ -123,7 +117,7 @@ class AgentTransformerPPO(BaseAgent):
         self._entropy_coeff = float(h.get("entropy_coeff", 0.0))
         self._value_coeff = float(h.get("value_coeff", 0.5))
         self._max_grad_norm = float(h.get("max_grad_norm", 0.5))
-        self._reward_clip = float(h.get("reward_clip", 10.0))  # clip rewards to [-clip, 0]
+        self._reward_clip = float(h.get("reward_clip", 10.0))  # floor rewards at -clip
         self._actor_hidden_dim = int(
             h.get("actor_hidden_dim", max(32, self._d_model * 2))
         )
@@ -198,7 +192,6 @@ class AgentTransformerPPO(BaseAgent):
             # (flush PPO → rebuild layout → re-validate rules).
             state.obs_names_tuple = new_obs
             state.action_names_tuple = new_act
-            state.entity_specs_signature = self._signature(metadata)
             self._handle_topology_change(b)
 
     def predict(
@@ -418,7 +411,6 @@ class AgentTransformerPPO(BaseAgent):
         action_names: List[List[str]],
         metadata: Optional[Dict[str, Any]],
     ) -> None:
-        sig = self._signature(metadata)
         building_names = (
             (metadata or {}).get("building_names")
             if metadata is not None
@@ -433,7 +425,7 @@ class AgentTransformerPPO(BaseAgent):
                 else f"building_{b}"
             )
             state = self._build_one_per_building_state(
-                building_id, list(obs_n), list(act_n), sig
+                building_id, list(obs_n), list(act_n)
             )
             self._per_building.append(state)
 
@@ -442,7 +434,6 @@ class AgentTransformerPPO(BaseAgent):
         building_id: str,
         observation_names: List[str],
         action_names: List[str],
-        entity_specs_signature: Optional[str],
     ) -> _PerBuildingState:
         layout = self._layout_builder.build(
             building_id, observation_names, action_names
@@ -496,7 +487,6 @@ class AgentTransformerPPO(BaseAgent):
             layout=layout,
             obs_names_tuple=tuple(observation_names),
             action_names_tuple=tuple(action_names),
-            entity_specs_signature=entity_specs_signature,
         )
 
     def _handle_topology_change(self, building_idx: int) -> None:
@@ -646,13 +636,6 @@ class AgentTransformerPPO(BaseAgent):
         for tname, sro_cfg in self._tokenizer_config.sro_types.items():
             dims.setdefault(tname, int(sro_cfg.input_dim_fallback))
         return dims
-
-    @staticmethod
-    def _signature(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
-        if not metadata or "entity_specs" not in metadata or not metadata["entity_specs"]:
-            return None
-        s = _json.dumps(metadata["entity_specs"], sort_keys=True, default=str)
-        return hashlib.sha256(s.encode()).hexdigest()[:16]
 
     @staticmethod
     def _infer_obs_dim(layout: BuildingTokenLayout) -> int:

--- a/algorithms/agents/base_agent.py
+++ b/algorithms/agents/base_agent.py
@@ -1,8 +1,8 @@
 from abc import abstractmethod
+from typing import Any, ClassVar, Dict, List, Optional
 import os
 import sys
 import time
-from typing import Any, Dict, List, Optional
 
 _BASE_AGENT_TRACE_ENABLED = (
     os.environ.get("OPEVA_STARTUP_TRACE", "1").strip().lower()
@@ -43,6 +43,7 @@ class BaseAgent(Module, ExecutionUnit):
     interchangeable from the wrapper's perspective.
     """
 
+    supports_dynamic_topology: ClassVar[bool] = False
     def __init__(self) -> None:
         super().__init__()
 

--- a/algorithms/agents/rbc_agent.py
+++ b/algorithms/agents/rbc_agent.py
@@ -55,6 +55,7 @@ class RuleBasedPolicy(BaseAgent):
     """Simple heuristic controller that prioritises PV utilisation while respecting EV requirements."""
 
     _use_raw_observations: bool = True
+    supports_dynamic_topology = True
 
     def __init__(self, config: Dict[str, Any]) -> None:
         super().__init__()

--- a/algorithms/registry.py
+++ b/algorithms/registry.py
@@ -66,6 +66,9 @@ _registry_trace("after MATD3 import")
 _registry_trace("before PPO agents import")
 from algorithms.agents.ppo_agents import HAPPO, IPPO, MAPPO
 _registry_trace("after PPO agents import")
+_registry_trace("before AgentTransformerPPO agents import")
+from algorithms.agents.agent_transformer_ppo import AgentTransformerPPO
+_registry_trace("after AgentTransformerPPO agents import")
 _registry_trace("before RuleBasedPolicy import")
 from algorithms.agents.rbc_agent import RuleBasedPolicy
 _registry_trace("after RuleBasedPolicy import")
@@ -95,6 +98,7 @@ ALGORITHM_REGISTRY: Dict[str, Type[BaseAgent]] = {
     "RandomPolicy": RandomPolicy,
     "RuleBasedPolicy": RuleBasedPolicy,
     "SignalAwareRBC": SignalAwareRBC,
+    "AgentTransformerPPO": AgentTransformerPPO,
 }
 
 PLACEHOLDER_ALGORITHMS = {
@@ -166,7 +170,7 @@ def _stage_to_agent_view(global_config: Dict[str, Any], stage_cfg: Dict[str, Any
         "name": stage_cfg["algorithm"],
         "hyperparameters": stage_cfg.get("hyperparameters", {}) or {},
     }
-    for optional_key in ("networks", "replay_buffer", "exploration", "policy"):
+    for optional_key in ("networks", "replay_buffer", "exploration", "policy", "tokenizer_config_path", "transformer"):
         if optional_key in stage_cfg and stage_cfg[optional_key] is not None:
             algorithm_block[optional_key] = stage_cfg[optional_key]
     agent_view["algorithm"] = algorithm_block

--- a/tests/fixtures/tokenizer_dummy_env.json
+++ b/tests/fixtures/tokenizer_dummy_env.json
@@ -1,0 +1,88 @@
+{
+  "type_embeddings": {"SRO": 0, "NFC": 1, "CA": 2},
+  "excluded_features": {
+    "patterns": [
+      "^district__topology_version$",
+      "^electric_vehicle_charger_state$",
+      "^electric_vehicle_soc$",
+      "^electric_vehicle_required_soc_departure$",
+      "^electric_vehicle_departure_time$",
+      "^electric_vehicle_is_flexible$",
+      "^active_chargers_count$",
+      "^active_storages_count$",
+      "^active_pvs_count$",
+      "^solar_generation$"
+    ]
+  },
+  "nfc": {
+    "type_name": "building_nfc",
+    "entity_table": "building",
+    "expression": {
+      "op": "subtract",
+      "left": {"feature": "load_power_kw"},
+      "right": {"feature": "pv_power_kw"}
+    }
+  },
+  "ca_types": {
+    "storage": {
+      "entity_table": "storage",
+      "action_field": "electrical_storage",
+      "input_dim_fallback": 1
+    },
+    "charger": {
+      "entity_table": "charger",
+      "action_field": "electric_vehicle_storage",
+      "input_dim_fallback": 4
+    }
+  },
+  "sro_types": {
+    "district_time": {
+      "entity_table": "district",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^district__hour$",
+        "^district__minutes$"
+      ],
+      "input_dim_fallback": 2
+    },
+    "pv": {
+      "entity_table": "pv",
+      "cardinality": "per_asset",
+      "adapter_prefix": "pv::",
+      "input_dim_fallback": 1
+    },
+    "ev_connected": {
+      "entity_table": "ev",
+      "cardinality": "per_asset",
+      "adapter_prefix": "charger::",
+      "adapter_label": "connected_ev",
+      "input_dim_fallback": 1
+    },
+    "ev_incoming": {
+      "entity_table": "ev",
+      "cardinality": "per_asset",
+      "adapter_prefix": "charger::",
+      "adapter_label": "incoming_ev",
+      "input_dim_fallback": 1
+    },
+    "building_meta": {
+      "entity_table": "building",
+      "cardinality": "singleton",
+      "feature_patterns": [
+        "^active_deferrable_appliances_count$"
+      ],
+      "input_dim_fallback": 1
+    },
+    "deferrable_appliance": {
+      "entity_table": "deferrable_appliance",
+      "cardinality": "per_asset",
+      "adapter_prefix": "deferrable_appliance::",
+      "input_dim_fallback": 5
+    }
+  },
+  "validation": {
+    "unmatched_features": "fail",
+    "ambiguous_pattern_match": "fail",
+    "input_dim_mismatch": "fail"
+  }
+}

--- a/tests/test_agent_transformer_ppo.py
+++ b/tests/test_agent_transformer_ppo.py
@@ -1,0 +1,403 @@
+"""AgentTransformerPPO unit tests.
+
+Covers:
+- ``predict`` returns ``[B][N_ca]`` floats clamped to ``[-1, 1]``.
+- ``update`` accumulates rollouts and runs PPO step on ``update_step``.
+- Topology change rebuilds layout, preserves weights for stable types.
+- Layout-drift on existing type (feature-count change) hard-fails.
+- New type appearing on existing tokenizer hard-fails.
+- ``save_checkpoint`` / ``load_checkpoint`` round-trip + signature mismatch
+  rejection.
+- ``export_artifacts`` returns a well-formed manifest with one entry per
+  building and TorchScript files on disk.
+- Registered in ``algorithms.registry.ALGORITHM_REGISTRY``.
+"""
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import pytest
+import torch
+
+from algorithms.agents.agent_transformer_ppo import (
+    AgentTransformerPPO,
+    _synthetic_sample_from_obs_names,
+)
+from algorithms.registry import ALGORITHM_REGISTRY, build_execution_unit
+from tests._entity_sample_obs_names import (
+    load_sample_observation_names_for_first_building,
+)
+
+
+_TOKENIZER_CFG = "configs/tokenizers/entity_default.json"
+_DEFAULT_ACTIONS = ["electrical_storage", "electric_vehicle_storage"]
+
+
+def _base_config() -> dict:
+    return {
+        "algorithm": {
+            "name": "AgentTransformerPPO",
+            "tokenizer_config_path": _TOKENIZER_CFG,
+            "transformer": {
+                "d_model": 16,
+                "nhead": 2,
+                "num_layers": 1,
+                "dim_feedforward": 32,
+                "dropout": 0.0,
+            },
+            "hyperparameters": {
+                "learning_rate": 1.0e-3,
+                "gamma": 0.99,
+                "gae_lambda": 0.95,
+                "clip_eps": 0.2,
+                "ppo_epochs": 1,
+                "minibatch_size": 4,
+                "entropy_coeff": 0.0,
+                "value_coeff": 0.5,
+                "max_grad_norm": 0.5,
+                "actor_hidden_dim": 32,
+                "critic_hidden_dim": 32,
+            },
+        },
+    }
+
+
+def _make_agent(n_buildings: int = 1) -> tuple[AgentTransformerPPO, List[List[str]], List[List[str]], int]:
+    obs_names = load_sample_observation_names_for_first_building()
+    obs_names_per = [list(obs_names) for _ in range(n_buildings)]
+    act_names_per = [list(_DEFAULT_ACTIONS) for _ in range(n_buildings)]
+    agent = AgentTransformerPPO(_base_config())
+    agent.attach_environment(
+        observation_names=obs_names_per,
+        action_names=act_names_per,
+        action_space=[None] * n_buildings,
+        observation_space=[None] * n_buildings,
+        metadata={"building_names": [f"Building_{b+1}" for b in range(n_buildings)]},
+    )
+    obs_dim = max(
+        max(seg.feature_indices) for seg in agent._per_building[0].layout.segments
+    ) + 1
+    return agent, obs_names_per, act_names_per, obs_dim
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_registered_under_canonical_name() -> None:
+    assert ALGORITHM_REGISTRY.get("AgentTransformerPPO") is AgentTransformerPPO
+
+
+def test_create_agent_via_registry() -> None:
+    base = _base_config()
+    algo = base.pop("algorithm")
+    stage = {"algorithm": algo.pop("name")}
+    stage.update(algo)
+    base["pipeline"] = [stage]
+    agent = build_execution_unit(base)
+    assert isinstance(agent, AgentTransformerPPO)
+
+
+def test_supports_dynamic_topology_classvar_true() -> None:
+    assert AgentTransformerPPO.supports_dynamic_topology is True
+
+
+# ---------------------------------------------------------------------------
+# predict / update
+# ---------------------------------------------------------------------------
+
+
+def test_predict_shape_and_range() -> None:
+    agent, _, _, obs_dim = _make_agent(n_buildings=2)
+    obs = [np.random.rand(obs_dim).astype(np.float64) for _ in range(2)]
+    actions = agent.predict(obs, deterministic=False)
+    assert isinstance(actions, list) and len(actions) == 2
+    for b, vec in enumerate(actions):
+        assert isinstance(vec, list)
+        assert len(vec) == agent._per_building[b].layout.n_ca
+        for v in vec:
+            assert -1.0 <= v <= 1.0
+
+
+def test_predict_deterministic_is_repeatable() -> None:
+    agent, _, _, obs_dim = _make_agent(n_buildings=1)
+    obs = [np.zeros(obs_dim, dtype=np.float64)]
+    a1 = agent.predict(obs, deterministic=True)
+    a2 = agent.predict(obs, deterministic=True)
+    assert a1 == a2
+
+
+def test_update_appends_to_buffer_then_ppo_step_clears() -> None:
+    agent, _, _, obs_dim = _make_agent(n_buildings=1)
+    state = agent._per_building[0]
+    rng = np.random.default_rng(0)
+    n_ca = state.layout.n_ca
+
+    # Five non-update steps → buffer fills
+    for _ in range(5):
+        obs = [rng.standard_normal(obs_dim)]
+        next_obs = [rng.standard_normal(obs_dim)]
+        actions_arr = rng.uniform(-0.5, 0.5, size=(n_ca,))
+        agent.update(
+            observations=obs,
+            actions=[actions_arr],
+            rewards=[0.1],
+            next_observations=next_obs,
+            terminated=False,
+            truncated=False,
+            update_target_step=False,
+            global_learning_step=0,
+            update_step=False,
+            initial_exploration_done=True,
+        )
+    assert len(state.buffer) == 5
+
+    # Snapshot a parameter to confirm gradient step actually moved weights.
+    p_before = next(state.actor.parameters()).clone().detach()
+
+    obs = [rng.standard_normal(obs_dim)]
+    next_obs = [rng.standard_normal(obs_dim)]
+    actions_arr = rng.uniform(-0.5, 0.5, size=(n_ca,))
+    agent.update(
+        observations=obs,
+        actions=[actions_arr],
+        rewards=[0.1],
+        next_observations=next_obs,
+        terminated=False,
+        truncated=False,
+        update_target_step=False,
+        global_learning_step=0,
+        update_step=True,
+        initial_exploration_done=True,
+    )
+    assert len(state.buffer) == 0  # cleared after PPO step
+    p_after = next(state.actor.parameters()).clone().detach()
+    assert not torch.allclose(p_before, p_after), "PPO step should update actor weights"
+
+
+# ---------------------------------------------------------------------------
+# Topology change handling
+# ---------------------------------------------------------------------------
+
+
+def test_topology_change_no_op_when_names_unchanged() -> None:
+    agent, obs_per, act_per, _ = _make_agent(n_buildings=1)
+    state_before = agent._per_building[0]
+    actor_id_before = id(state_before.actor)
+    agent.attach_environment(
+        observation_names=copy.deepcopy(obs_per),
+        action_names=copy.deepcopy(act_per),
+        action_space=[None],
+        observation_space=[None],
+        metadata={"building_names": ["Building_1"]},
+    )
+    # Same instance — no rebuild.
+    assert id(agent._per_building[0].actor) == actor_id_before
+
+
+def test_topology_change_rebuilds_layout_and_preserves_weights() -> None:
+    """Add a second charger (and its EV blocks). The 'charger' projection
+    weights survive (per-type weight sharing) and the layout grows by one
+    CA segment."""
+    agent, obs_per, act_per, _ = _make_agent(n_buildings=1)
+    state = agent._per_building[0]
+    n_ca_before = state.layout.n_ca
+    # Snapshot the storage projection weights — should survive the rebuild.
+    storage_w_before = state.tokenizer.projections["storage"].weight.detach().clone()
+    charger_w_before = state.tokenizer.projections["charger"].weight.detach().clone()
+    actor_w_before = next(state.actor.parameters()).detach().clone()
+
+    # Identify existing charger block and replicate it under a fresh id.
+    orig_id = next(
+        n.split("::")[1]
+        for n in obs_per[0]
+        if n.startswith("charger::") and "::connected_ev::" not in n and "::incoming_ev::" not in n
+    )
+    new_id = "Building_1/charger_NEW"
+    new_obs: List[str] = []
+    new_block: List[str] = []
+    for n in obs_per[0]:
+        new_obs.append(n)
+        if n.startswith(f"charger::{orig_id}::"):
+            # Append a parallel entry for the new charger right after each
+            # existing one (order doesn't matter to the layout builder, but
+            # this keeps the diff readable).
+            new_block.append(n.replace(f"charger::{orig_id}::", f"charger::{new_id}::", 1))
+    new_obs.extend(new_block)
+    new_acts = list(act_per[0]) + ["electric_vehicle_storage"]
+
+    agent.attach_environment(
+        observation_names=[new_obs],
+        action_names=[new_acts],
+        action_space=[None],
+        observation_space=[None],
+        metadata={"building_names": ["Building_1"]},
+    )
+
+    state_after = agent._per_building[0]
+    assert state_after.layout.n_ca == n_ca_before + 1
+    # Per-type weights preserved
+    assert torch.allclose(
+        storage_w_before,
+        state_after.tokenizer.projections["storage"].weight,
+    )
+    assert torch.allclose(
+        charger_w_before,
+        state_after.tokenizer.projections["charger"].weight,
+    )
+    # Actor preserved (per-CA weight sharing)
+    actor_w_after = next(state_after.actor.parameters())
+    assert torch.allclose(actor_w_before, actor_w_after)
+
+
+def test_topology_change_feature_count_drift_hard_fails() -> None:
+    """Inject an extra storage feature that wasn't present at attach time —
+    feature count for type 'storage' changes. Must raise."""
+    agent, obs_per, act_per, _ = _make_agent(n_buildings=1)
+    storage_id = next(
+        n.split("::")[1] for n in obs_per[0] if n.startswith("storage::")
+    )
+    drifted = list(obs_per[0])
+    drifted.append(f"storage::{storage_id}::brand_new_storage_feature")
+
+    with pytest.raises(ValueError, match=r"feature count for type 'storage'"):
+        agent.attach_environment(
+            observation_names=[drifted],
+            action_names=copy.deepcopy(act_per),
+            action_space=[None],
+            observation_space=[None],
+            metadata={"building_names": ["Building_1"]},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Checkpointing
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_round_trip(tmp_path: Path) -> None:
+    agent, _, _, _ = _make_agent(n_buildings=1)
+    # Mutate weights so round-trip is meaningful.
+    with torch.no_grad():
+        for p in agent._per_building[0].actor.parameters():
+            p.add_(0.1)
+    actor_w = (
+        next(agent._per_building[0].actor.parameters()).detach().clone()
+    )
+    path = agent.save_checkpoint(str(tmp_path), step=42)
+    assert path is not None and Path(path).exists()
+
+    # Build a fresh agent with identical layout and load.
+    obs_names = load_sample_observation_names_for_first_building()
+    fresh = AgentTransformerPPO(_base_config())
+    fresh.attach_environment(
+        observation_names=[list(obs_names)],
+        action_names=[list(_DEFAULT_ACTIONS)],
+        action_space=[None],
+        observation_space=[None],
+        metadata={"building_names": ["Building_1"]},
+    )
+    fresh.load_checkpoint(path)
+    actor_w_loaded = next(fresh._per_building[0].actor.parameters()).detach()
+    assert torch.allclose(actor_w, actor_w_loaded)
+
+
+def test_checkpoint_layout_signature_mismatch_rejected(tmp_path: Path) -> None:
+    """Save a 1-building checkpoint, then try to load into a 2-building agent.
+    Cardinality mismatch is rejected before signature check, exercising the
+    same guarantee (cross-topology resume disallowed)."""
+    agent, _, _, _ = _make_agent(n_buildings=1)
+    path = agent.save_checkpoint(str(tmp_path), step=1)
+    assert path is not None
+
+    fresh, _, _, _ = _make_agent(n_buildings=2)
+    with pytest.raises(ValueError, match=r"Cross-cardinality resume|layout_signature"):
+        fresh.load_checkpoint(path)
+
+
+def test_checkpoint_signature_mismatch_same_cardinality(tmp_path: Path) -> None:
+    """Save with the bundled obs_names; reload into an agent whose obs_names
+    have an extra (allowed) charger appended → signature differs but
+    cardinality matches → ``layout_signature mismatch`` raised."""
+    agent, obs_per, act_per, _ = _make_agent(n_buildings=1)
+    path = agent.save_checkpoint(str(tmp_path), step=1)
+    assert path is not None
+
+    # Build a fresh agent with one extra charger (same trick as the
+    # rebuild test) — different obs_names_tuple.
+    orig_id = next(
+        n.split("::")[1]
+        for n in obs_per[0]
+        if n.startswith("charger::") and "::connected_ev::" not in n and "::incoming_ev::" not in n
+    )
+    new_id = "Building_1/charger_NEW"
+    extended = list(obs_per[0]) + [
+        n.replace(f"charger::{orig_id}::", f"charger::{new_id}::", 1)
+        for n in obs_per[0]
+        if n.startswith(f"charger::{orig_id}::")
+    ]
+
+    fresh = AgentTransformerPPO(_base_config())
+    fresh.attach_environment(
+        observation_names=[extended],
+        action_names=[list(act_per[0]) + ["electric_vehicle_storage"]],
+        action_space=[None],
+        observation_space=[None],
+        metadata={"building_names": ["Building_1"]},
+    )
+    with pytest.raises(ValueError, match=r"layout_signature mismatch"):
+        fresh.load_checkpoint(path)
+
+
+# ---------------------------------------------------------------------------
+# Artifact export
+# ---------------------------------------------------------------------------
+
+
+def test_export_artifacts_writes_files_and_returns_manifest(tmp_path: Path) -> None:
+    agent, _, _, _ = _make_agent(n_buildings=2)
+    manifest = agent.export_artifacts(
+        str(tmp_path), context={"topology_version": 7}
+    )
+    assert manifest["format"] == "onnx"
+    assert manifest["supports_dynamic_topology"] is True
+    assert manifest["tokenizer_config_path"] == _TOKENIZER_CFG
+    assert len(manifest["artifacts"]) == 2
+    assert len(manifest["agent_models"]) == 2
+    for entry in manifest["artifacts"]:
+        p = tmp_path / entry["path"]
+        assert p.exists() and p.stat().st_size > 0
+        assert entry["path"].endswith(".onnx")
+        assert "topology_v7" in entry["path"]
+        assert entry["config"]["n_ca"] == 2
+        assert set(entry["config"]["ca_types"]) <= {"storage", "charger"}
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-sample reverse parser
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_sample_routes_features_by_table() -> None:
+    obs = [
+        "district__hour",
+        "non_shiftable_load",
+        "storage::s1::soc",
+        "pv::p1::generation",
+        "charger::c1::state",
+        "charger::c1::connected_ev::soc",
+        "charger::c1::incoming_ev::departure",
+    ]
+    sample = _synthetic_sample_from_obs_names(obs)
+    feats = sample.feature_names_per_table
+    assert "district__hour" in feats["district"]
+    assert "non_shiftable_load" in feats["building"]
+    assert "soc" in feats["storage"]
+    assert "generation" in feats["pv"]
+    assert "state" in feats["charger"]
+    assert {"soc", "departure"} <= set(feats["ev"])

--- a/tests/test_agent_transformer_ppo.py
+++ b/tests/test_agent_transformer_ppo.py
@@ -8,14 +8,13 @@ Covers:
 - New type appearing on existing tokenizer hard-fails.
 - ``save_checkpoint`` / ``load_checkpoint`` round-trip + signature mismatch
   rejection.
-- ``export_artifacts`` returns a well-formed manifest with one entry per
-  building and TorchScript files on disk.
+- ``export_artifacts`` returns a well-formed manifest with one ONNX file
+  per building.
 - Registered in ``algorithms.registry.ALGORITHM_REGISTRY``.
 """
 from __future__ import annotations
 
 import copy
-import json
 from pathlib import Path
 from typing import List
 

--- a/tests/test_agent_transformer_ppo_wrapper_integration.py
+++ b/tests/test_agent_transformer_ppo_wrapper_integration.py
@@ -1,0 +1,190 @@
+"""Integration of AgentTransformerPPO with Wrapper_CityLearn
+over the entity interface in dynamic-topology mode.
+
+Reuses the dummy entity env from ``tests/test_wrapper_entity_mode.py`` but
+overrides ``action_names`` so the per-building action list uses the bare
+``action_field`` (matching the layout-builder contract). A purpose-built
+tokenizer config under ``tests/fixtures/tokenizer_dummy_env.json`` matches
+the dummy env's feature schema.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import numpy as np
+import pytest
+from gymnasium import spaces
+
+from algorithms.agents.agent_transformer_ppo import AgentTransformerPPO
+from tests.test_wrapper_entity_mode import _DummyEntityEnv, _entity_config
+from utils.wrapper_citylearn import Wrapper_CityLearn
+
+
+_TOKENIZER_FIXTURE = "tests/fixtures/tokenizer_dummy_env.json"
+
+
+class _DummyEntityEnvForPPO(_DummyEntityEnv):
+    """Dummy env whose action_names use bare ``action_field`` strings.
+
+    The base test fixture suffixes charger IDs onto the action field
+    (``electric_vehicle_storage_C1``); the v2 layout builder matches
+    action_field exactly, so we strip the suffix here.
+    """
+
+    @property
+    def action_names(self) -> List[List[str]]:  # type: ignore[override]
+        if self._version == 0:
+            return [["electrical_storage", "electric_vehicle_storage"]]
+        return [
+            ["electrical_storage", "electric_vehicle_storage"],
+            ["electrical_storage", "electric_vehicle_storage"],
+        ]
+
+
+def _ppo_algo_config() -> Dict[str, Any]:
+    return {
+        "name": "AgentTransformerPPO",
+        "tokenizer_config_path": _TOKENIZER_FIXTURE,
+        "transformer": {
+            "d_model": 16,
+            "nhead": 2,
+            "num_layers": 1,
+            "dim_feedforward": 32,
+            "dropout": 0.0,
+        },
+        "hyperparameters": {
+            "learning_rate": 1.0e-3,
+            "gamma": 0.99,
+            "gae_lambda": 0.95,
+            "clip_eps": 0.2,
+            "ppo_epochs": 1,
+            "minibatch_size": 4,
+            "entropy_coeff": 0.0,
+            "value_coeff": 0.5,
+            "max_grad_norm": 0.5,
+            "actor_hidden_dim": 32,
+            "critic_hidden_dim": 32,
+        },
+    }
+
+
+def _ppo_full_config() -> Dict[str, Any]:
+    """Wrapper-shape config (the agent constructor expects ``cfg["algorithm"]``)."""
+    return {"algorithm": _ppo_algo_config()}
+
+
+def _wrapper_config_with_ppo() -> Dict[str, Any]:
+    cfg = _entity_config()
+    cfg["algorithm"] = _ppo_algo_config()
+    return cfg
+
+
+def test_wrapper_attaches_transformer_ppo_with_entity_dynamic() -> None:
+    """The dynamic-topology guardrail must accept ``AgentTransformerPPO``
+    (it has ``supports_dynamic_topology=True``) and ``set_model`` must
+    drive a single ``attach_environment`` call."""
+    env = _DummyEntityEnvForPPO()
+    wrapper = Wrapper_CityLearn(
+        env=env, config=_wrapper_config_with_ppo(), job_id="ppo-entity"
+    )
+    agent = AgentTransformerPPO(_ppo_full_config())
+    wrapper.set_model(agent)
+
+    # One per-building stack initialised at version 0.
+    assert len(agent._per_building) == 1
+    state = agent._per_building[0]
+    assert state.layout.n_ca == 2  # storage + charger
+
+
+def test_wrapper_predict_returns_per_building_per_ca_actions() -> None:
+    env = _DummyEntityEnvForPPO()
+    wrapper = Wrapper_CityLearn(
+        env=env, config=_wrapper_config_with_ppo(), job_id="ppo-entity-predict"
+    )
+    agent = AgentTransformerPPO(_ppo_full_config())
+    wrapper.set_model(agent)
+
+    payload = env._observation_payload(version=0)
+    adapted = wrapper._apply_entity_layout(payload, force_attach=False)
+    assert isinstance(adapted, list) and len(adapted) == 1
+
+    actions = agent.predict(adapted, deterministic=True)
+    assert len(actions) == 1
+    assert len(actions[0]) == 2  # storage + charger CA
+    for v in actions[0]:
+        assert -1.0 <= v <= 1.0
+
+
+def test_wrapper_topology_change_triggers_agent_rebuild() -> None:
+    """Bump ``_version`` to add a second building; the wrapper re-attaches
+    on the next ``_apply_entity_layout``, and the agent rebuilds its stacks
+    accordingly."""
+    env = _DummyEntityEnvForPPO()
+    wrapper = Wrapper_CityLearn(
+        env=env, config=_wrapper_config_with_ppo(), job_id="ppo-entity-topo"
+    )
+    agent = AgentTransformerPPO(_ppo_full_config())
+    wrapper.set_model(agent)
+    assert len(agent._per_building) == 1
+
+    env._version = 1
+    new_payload = env._observation_payload(version=1)
+    adapted = wrapper._apply_entity_layout(new_payload, force_attach=False)
+    assert len(adapted) == 2
+    assert len(agent._per_building) == 2
+    for state in agent._per_building:
+        assert state.layout.n_ca == 2
+
+
+def test_wrapper_to_env_actions_round_trips_ppo_output() -> None:
+    """``predict`` -> ``_to_env_actions`` produces the entity-tabled action
+    payload the simulator expects."""
+    env = _DummyEntityEnvForPPO()
+    wrapper = Wrapper_CityLearn(
+        env=env, config=_wrapper_config_with_ppo(), job_id="ppo-entity-actions"
+    )
+    agent = AgentTransformerPPO(_ppo_full_config())
+    wrapper.set_model(agent)
+
+    payload = env._observation_payload(version=0)
+    adapted = wrapper._apply_entity_layout(payload, force_attach=False)
+    actions = agent.predict(adapted, deterministic=True)
+
+    env_payload = wrapper._to_env_actions(actions)
+    assert "tables" in env_payload
+    # storage CA -> building action table; charger CA -> charger action table.
+    assert env_payload["tables"]["building"].shape == (1, 1)
+    assert env_payload["tables"]["charger"].shape == (1, 1)
+
+
+def test_non_dynamic_agent_in_entity_dynamic_still_rejected_on_topology_change() -> None:
+    """The flag-based guardrail must reject non-dynamic agents when the
+    topology actually mutates."""
+
+    class _NonDynamicModel:
+        supports_dynamic_topology = False
+        use_raw_observations = True
+
+        def attach_environment(self, **_kwargs):
+            pass
+
+        def predict(self, observations, deterministic=None):
+            return [[0.0, 0.0] for _ in observations]
+
+        def update(self, **_kwargs):
+            pass
+
+        def is_initial_exploration_done(self, _):
+            return True
+
+    env = _DummyEntityEnvForPPO()
+    cfg = _entity_config()
+    cfg["pipeline"] = [{"algorithm": "MADDPG", "count": 1, "hyperparameters": {}}]
+    wrapper = Wrapper_CityLearn(env=env, config=cfg, job_id="ppo-entity-guard")
+    wrapper.set_model(_NonDynamicModel())
+
+    env._version = 1
+    with pytest.raises(ValueError, match=r"MADDPG|dynamic"):
+        wrapper._apply_entity_layout(
+            env._observation_payload(version=1), force_attach=False
+        )

--- a/tests/test_agent_transformer_ppo_wrapper_integration.py
+++ b/tests/test_agent_transformer_ppo_wrapper_integration.py
@@ -11,9 +11,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-import numpy as np
 import pytest
-from gymnasium import spaces
 
 from algorithms.agents.agent_transformer_ppo import AgentTransformerPPO
 from tests.test_wrapper_entity_mode import _DummyEntityEnv, _entity_config
@@ -73,19 +71,13 @@ def _ppo_full_config() -> Dict[str, Any]:
     return {"algorithm": _ppo_algo_config()}
 
 
-def _wrapper_config_with_ppo() -> Dict[str, Any]:
-    cfg = _entity_config()
-    cfg["algorithm"] = _ppo_algo_config()
-    return cfg
-
-
 def test_wrapper_attaches_transformer_ppo_with_entity_dynamic() -> None:
     """The dynamic-topology guardrail must accept ``AgentTransformerPPO``
     (it has ``supports_dynamic_topology=True``) and ``set_model`` must
     drive a single ``attach_environment`` call."""
     env = _DummyEntityEnvForPPO()
     wrapper = Wrapper_CityLearn(
-        env=env, config=_wrapper_config_with_ppo(), job_id="ppo-entity"
+        env=env, config=_entity_config(), job_id="ppo-entity"
     )
     agent = AgentTransformerPPO(_ppo_full_config())
     wrapper.set_model(agent)
@@ -99,7 +91,7 @@ def test_wrapper_attaches_transformer_ppo_with_entity_dynamic() -> None:
 def test_wrapper_predict_returns_per_building_per_ca_actions() -> None:
     env = _DummyEntityEnvForPPO()
     wrapper = Wrapper_CityLearn(
-        env=env, config=_wrapper_config_with_ppo(), job_id="ppo-entity-predict"
+        env=env, config=_entity_config(), job_id="ppo-entity-predict"
     )
     agent = AgentTransformerPPO(_ppo_full_config())
     wrapper.set_model(agent)
@@ -121,7 +113,7 @@ def test_wrapper_topology_change_triggers_agent_rebuild() -> None:
     accordingly."""
     env = _DummyEntityEnvForPPO()
     wrapper = Wrapper_CityLearn(
-        env=env, config=_wrapper_config_with_ppo(), job_id="ppo-entity-topo"
+        env=env, config=_entity_config(), job_id="ppo-entity-topo"
     )
     agent = AgentTransformerPPO(_ppo_full_config())
     wrapper.set_model(agent)
@@ -141,7 +133,7 @@ def test_wrapper_to_env_actions_round_trips_ppo_output() -> None:
     payload the simulator expects."""
     env = _DummyEntityEnvForPPO()
     wrapper = Wrapper_CityLearn(
-        env=env, config=_wrapper_config_with_ppo(), job_id="ppo-entity-actions"
+        env=env, config=_entity_config(), job_id="ppo-entity-actions"
     )
     agent = AgentTransformerPPO(_ppo_full_config())
     wrapper.set_model(agent)

--- a/tests/test_supports_dynamic_topology.py
+++ b/tests/test_supports_dynamic_topology.py
@@ -1,0 +1,22 @@
+"""Pin the ``supports_dynamic_topology`` ClassVar on each registered agent
+class so the wrapper guardrail and config validator agree on capability."""
+
+from __future__ import annotations
+
+
+def test_base_agent_default_is_false() -> None:
+    from algorithms.agents.base_agent import BaseAgent
+
+    assert BaseAgent.supports_dynamic_topology is False
+
+
+def test_maddpg_does_not_support_dynamic_topology() -> None:
+    from algorithms.agents.maddpg_agent import MADDPG
+
+    assert MADDPG.supports_dynamic_topology is False
+
+
+def test_rule_based_policy_supports_dynamic_topology() -> None:
+    from algorithms.agents.rbc_agent import RuleBasedPolicy
+
+    assert RuleBasedPolicy.supports_dynamic_topology is True

--- a/tests/test_supports_dynamic_topology.py
+++ b/tests/test_supports_dynamic_topology.py
@@ -20,3 +20,9 @@ def test_rule_based_policy_supports_dynamic_topology() -> None:
     from algorithms.agents.rbc_agent import RuleBasedPolicy
 
     assert RuleBasedPolicy.supports_dynamic_topology is True
+
+
+def test_agent_transformer_ppo_supports_dynamic_topology() -> None:
+    from algorithms.agents.agent_transformer_ppo import AgentTransformerPPO
+
+    assert AgentTransformerPPO.supports_dynamic_topology is True


### PR DESCRIPTION
## What

Per-building Transformer + PPO agent that stitches together the modules
merged in WP06-01/02/03, plus the small `BaseAgent` contract change and
the registry wiring that lets `run_experiment.py` instantiate it.

## Files (8 / +1,642 / −2)

- `algorithms/agents/agent_transformer_ppo.py` (new, 934)
- `algorithms/agents/base_agent.py` (+3 / −1) — `supports_dynamic_topology: ClassVar[bool] = False` default; `predict` gains `*, context: Any = None`
- `algorithms/agents/rbc_agent.py` (+1) — overrides `supports_dynamic_topology = True`
- `algorithms/registry.py` (+6 / −1) — register `AgentTransformerPPO`; propagate `tokenizer_config_path` + `transformer` in `_stage_to_agent_view`
- `tests/test_agent_transformer_ppo.py` (new, 402)
- `tests/test_agent_transformer_ppo_wrapper_integration.py` (new, 182)
- `tests/test_supports_dynamic_topology.py` (new, 28)
- `tests/fixtures/tokenizer_dummy_env.json` (new, 88) — matches the dummy entity env schema

## What to review carefully

1. **`attach_environment` idempotence + topology detection**
   - First call → fresh build for every building.
   - Subsequent call with identical per-building `(observation_names, action_names)` → no-op (required: wrapper re-emits metadata on every reset).
   - Per-building drift → `_handle_topology_change(b)`.
   - Total building-count change → complete rebuild (verify this is acceptable for your scenarios).

2. **`_handle_topology_change` sequence** (`agent_transformer_ppo.py:493-602`):
   (1) flush rollout with PPO update on **old** layout, (2) clear buffer, (3) rebuild layout, (4) re-run 5 hard-fail rules against a synthetic sample reconstructed from new obs_names (rule 5 skipped — see comment on line 532), (5) reject feature-count drift on existing types, (6) bump `topology_version`. **Per-type projections are reused when input dim is unchanged; only new types get fresh weights.**

3. **`_stage_to_agent_view` propagation** (`registry.py`): adds `tokenizer_config_path` + `transformer` to the synthesized `algorithm` block. Without this the agent `KeyError`s at construction. Existing agents unaffected.

4. **`BaseAgent` contract addition**: `supports_dynamic_topology: ClassVar[bool] = False` default; `predict` gains `*, context: Any = None` (pipeline composability). All existing concrete agents inherit `False` (MADDPG unchanged); RBC overrides `True`; `AgentTransformerPPO` overrides `True`.

5. **Per-building checkpoint signature**: `tuple(sorted(obs_names_tuple))`. Cross-topology checkpoint resume rejected (documented contract).

6. **ONNX export**: `agent_<b>__topology_v<v>.onnx`; manifest records `topology_version` per artefact for deployment routing.

## Risk

Medium — this PR is the first in the stack that modifies existing files
(`base_agent.py`, `rbc_agent.py`, `registry.py`). Mitigated by:

- `BaseAgent.supports_dynamic_topology = False` default matches the
  behaviour untyped agents already had.
- `predict(context=)` is a keyword-only addition; existing callers
  unaffected.
- `_stage_to_agent_view` only propagates the two new keys when present
  in the stage dict; other agents don't see them.

## Verify

`pytest tests/test_agent_transformer_ppo.py tests/test_agent_transformer_ppo_wrapper_integration.py tests/test_supports_dynamic_topology.py tests/test_registry.py tests/test_config_validation.py`