### PR TITLE
Implement TransformerPPO behavior cloning 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ __pycache__/
 configs/local_ui_test_entity.yaml
 configs/local_ui_test_static.yaml
 .DS_Store
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ ALGORITHM_REGISTRY: Dict[str, Type[BaseAgent]] = {
 |-----------|-------------|
 | `MADDPG` | Multi-Agent DDPG with replay buffer, actor-critic networks |
 | `RuleBasedPolicy` | Heuristic controller for EV charging (uses raw observations) |
+| `AgentTransformerPPO` | Entity-interface Transformer PPO with dynamic-topology support and optional behavior cloning / warm-start via `RBCCommunityPolicy` |
 | `SingleAgentRL` | Schema placeholder only |
 
 ## Runtime Flow
@@ -132,6 +133,7 @@ Dynamic topology notes:
 - Wrapper rebuilds layout automatically on `topology_version` change.
 - Current guardrail: `MADDPG` in `entity+dynamic` raises fail-fast on runtime topology mutation.
   Use `RuleBasedPolicy` (or another dynamic-ready agent) for dynamic topology scenarios.
+- `AgentTransformerPPO` supports `entity+dynamic` and can optionally enable behavior cloning with an `RBCCommunityPolicy` warm-start teacher; BC teacher buffers are rebuilt or cleared when topology changes.
 
 ## Tokenizer Fixture (Entity Interface)
 

--- a/algorithms/agents/agent_transformer_ppo.py
+++ b/algorithms/agents/agent_transformer_ppo.py
@@ -33,6 +33,7 @@ from loguru import logger
 from torch import nn
 
 from algorithms.agents.base_agent import BaseAgent
+from algorithms.utils.behavior_cloning import BehaviorCloningRegularizer
 from algorithms.utils.entity_observation_tokenizer import (
     EntityObservationTokenizer,
 )
@@ -127,6 +128,11 @@ class AgentTransformerPPO(BaseAgent):
 
         self._layout_builder = EntityTokenLayoutBuilder(self._tokenizer_config)
         self._per_building: List[_PerBuildingState] = []
+        self._bc = BehaviorCloningRegularizer.from_config(algo, self.config)
+        self._latest_raw_observations: Optional[List[npt.NDArray[np.float64]]] = None
+        self._latest_encoded_observations: Optional[List[npt.NDArray[np.float64]]] = None
+        self._latest_global_learning_step = 0
+        self._latest_training_metrics: Dict[str, float] = {}
 
         # Tracks whether ``attach_environment`` has ever been called. The
         # very first call is not a topology change.
@@ -155,6 +161,13 @@ class AgentTransformerPPO(BaseAgent):
                 observation_names, action_names, metadata
             )
             self._first_attach_done = True
+            self._attach_bc_environment(
+                observation_names=observation_names,
+                action_names=action_names,
+                action_space=action_space,
+                observation_space=observation_space,
+                metadata=metadata,
+            )
             for st in self._per_building:
                 logger.info(
                     "Initial attach: {} — obs_dim={}, n_sro={}, n_ca={}, "
@@ -174,8 +187,16 @@ class AgentTransformerPPO(BaseAgent):
             self._build_all_per_building_states(
                 observation_names, action_names, metadata
             )
+            self._notify_bc_topology_change(
+                observation_names=observation_names,
+                action_names=action_names,
+                action_space=action_space,
+                observation_space=observation_space,
+                metadata=metadata,
+            )
             return
 
+        topology_changed = False
         for b, (obs_n, act_n) in enumerate(
             zip(observation_names, action_names)
         ):
@@ -193,6 +214,33 @@ class AgentTransformerPPO(BaseAgent):
             state.obs_names_tuple = new_obs
             state.action_names_tuple = new_act
             self._handle_topology_change(b)
+            topology_changed = True
+
+        if topology_changed:
+            self._notify_bc_topology_change(
+                observation_names=observation_names,
+                action_names=action_names,
+                action_space=action_space,
+                observation_space=observation_space,
+                metadata=metadata,
+            )
+
+    def set_observation_context(
+        self,
+        *,
+        raw_observations: Optional[List[npt.NDArray[np.float64]]] = None,
+        encoded_observations: Optional[List[npt.NDArray[np.float64]]] = None,
+    ) -> None:
+        self._latest_raw_observations = (
+            [np.asarray(obs, dtype=np.float64) for obs in raw_observations]
+            if raw_observations is not None
+            else None
+        )
+        self._latest_encoded_observations = (
+            [np.asarray(obs, dtype=np.float64) for obs in encoded_observations]
+            if encoded_observations is not None
+            else None
+        )
 
     def predict(
         self,
@@ -216,7 +264,15 @@ class AgentTransformerPPO(BaseAgent):
             # ActorHead returns ``[B, N_ca, 1]``; the wrapper expects a flat
             # per-CA list.
             out.append(actions.squeeze(0).squeeze(-1).clamp(-1.0, 1.0).tolist())
-        return out
+        if self._bc is None:
+            return out
+        teacher_observations = (
+            self._latest_raw_observations
+            if self._latest_raw_observations is not None
+            else observations
+        )
+        self._bc.compute_teacher_actions(teacher_observations)
+        return self._bc.maybe_phaseout(out, deterministic=det)
 
     def update(
         self,
@@ -234,7 +290,8 @@ class AgentTransformerPPO(BaseAgent):
     ) -> None:
         """Append the transition to each per-building rollout buffer; when
         ``update_step`` is true, run a PPO update per building and clear."""
-        del update_target_step, global_learning_step, initial_exploration_done
+        del update_target_step, initial_exploration_done
+        self._latest_global_learning_step = int(global_learning_step)
 
         done = bool(terminated or truncated)
         for b, state in enumerate(self._per_building):
@@ -263,13 +320,27 @@ class AgentTransformerPPO(BaseAgent):
                 value=value,
                 done=done,
             )
+            if self._bc is not None:
+                self._bc.record_transition(b)
 
         if not update_step:
             return
 
-        for state in self._per_building:
-            self._ppo_update(state, next_observations)
+        for b, state in enumerate(self._per_building):
+            self._ppo_update(b, state, next_observations)
             state.buffer.clear()
+            if self._bc is not None:
+                self._bc.on_buffer_flushed(b)
+
+    def get_diagnostic_metrics(self) -> Dict[str, float]:
+        if self._bc is None:
+            return {}
+        return self._bc.snapshot_metrics()
+
+    def consume_latest_training_metrics(self) -> Dict[str, float]:
+        metrics = dict(self._latest_training_metrics)
+        self._latest_training_metrics = {}
+        return metrics
 
     def export_artifacts(  # type: ignore[override]
         self,
@@ -429,6 +500,44 @@ class AgentTransformerPPO(BaseAgent):
             )
             self._per_building.append(state)
 
+    def _attach_bc_environment(
+        self,
+        *,
+        observation_names: List[List[str]],
+        action_names: List[List[str]],
+        action_space: List[Any],
+        observation_space: List[Any],
+        metadata: Optional[Dict[str, Any]],
+    ) -> None:
+        if self._bc is None:
+            return
+        self._bc.attach_environment(
+            observation_names=observation_names,
+            action_names=action_names,
+            action_space=action_space,
+            observation_space=observation_space,
+            metadata=metadata,
+        )
+
+    def _notify_bc_topology_change(
+        self,
+        *,
+        observation_names: List[List[str]],
+        action_names: List[List[str]],
+        action_space: List[Any],
+        observation_space: List[Any],
+        metadata: Optional[Dict[str, Any]],
+    ) -> None:
+        if self._bc is None:
+            return
+        self._bc.on_topology_change(
+            observation_names=observation_names,
+            action_names=action_names,
+            action_space=action_space,
+            observation_space=observation_space,
+            metadata=metadata,
+        )
+
     def _build_one_per_building_state(
         self,
         building_id: str,
@@ -507,7 +616,9 @@ class AgentTransformerPPO(BaseAgent):
                 # the conservative choice; a future improvement could
                 # forward through the new layout's critic.
                 self._run_ppo_update_with_last_value(
-                    state, last_value=torch.zeros(1)
+                    state,
+                    last_value=torch.zeros(1),
+                    building_idx=building_idx,
                 )
             finally:
                 state.buffer.clear()
@@ -666,6 +777,7 @@ class AgentTransformerPPO(BaseAgent):
 
     def _ppo_update(
         self,
+        building_idx: int,
         state: _PerBuildingState,
         next_observations: List[npt.NDArray[np.float64]],
     ) -> None:
@@ -689,9 +801,8 @@ class AgentTransformerPPO(BaseAgent):
             return
         # Bootstrap value from the next observation of this building.
         try:
-            b_idx = self._per_building.index(state)
-            next_obs = next_observations[b_idx]
-        except (ValueError, IndexError):
+            next_obs = next_observations[building_idx]
+        except IndexError:
             next_obs = None
         if next_obs is None:
             last_value = torch.zeros(1)
@@ -699,7 +810,11 @@ class AgentTransformerPPO(BaseAgent):
             last_value = self._critic_value(
                 state, np.asarray(next_obs, dtype=np.float64)
             )
-        self._run_ppo_update_with_last_value(state, last_value)
+        self._run_ppo_update_with_last_value(
+            state,
+            last_value,
+            building_idx=building_idx,
+        )
 
     def _critic_value(
         self,
@@ -715,7 +830,11 @@ class AgentTransformerPPO(BaseAgent):
             return state.critic(pooled).squeeze(-1)
 
     def _run_ppo_update_with_last_value(
-        self, state: _PerBuildingState, last_value: torch.Tensor
+        self,
+        state: _PerBuildingState,
+        last_value: torch.Tensor,
+        *,
+        building_idx: int,
     ) -> None:
         state.buffer.compute_returns_and_advantages(last_value)
         all_metrics: dict = {"policy_loss": [], "value_loss": [], "entropy": []}
@@ -749,6 +868,15 @@ class AgentTransformerPPO(BaseAgent):
                     value_coeff=self._value_coeff,
                     entropy_coeff=self._entropy_coeff,
                 )
+                if self._bc is not None:
+                    means = torch.tanh(state.actor.mlp(ca_emb))
+                    loss = loss + self._bc.bc_loss_term(
+                        building_idx=building_idx,
+                        layout=state.layout,
+                        predicted_means=means,
+                        step_indices=batch.step_indices,
+                        global_learning_step=self._latest_global_learning_step,
+                    )
                 loss.backward()
                 torch.nn.utils.clip_grad_norm_(
                     list(state.tokenizer.parameters())
@@ -761,6 +889,8 @@ class AgentTransformerPPO(BaseAgent):
                 for k, v in _metrics.items():
                     all_metrics.setdefault(k, []).append(v)
         averaged = {k: sum(v) / len(v) for k, v in all_metrics.items() if v}
+        if self._bc is not None:
+            self._latest_training_metrics.update(self._bc.snapshot_metrics())
         building_id = getattr(state, "building_id", "?")
         logger.info(
             "PPO update [{}]: policy_loss={:.4f}, value_loss={:.4f}, entropy={:.4f}, clip_frac={:.3f}",

--- a/algorithms/agents/agent_transformer_ppo.py
+++ b/algorithms/agents/agent_transformer_ppo.py
@@ -196,7 +196,7 @@ class AgentTransformerPPO(BaseAgent):
             )
             return
 
-        topology_changed = False
+        changed_buildings: List[int] = []
         for b, (obs_n, act_n) in enumerate(
             zip(observation_names, action_names)
         ):
@@ -214,15 +214,16 @@ class AgentTransformerPPO(BaseAgent):
             state.obs_names_tuple = new_obs
             state.action_names_tuple = new_act
             self._handle_topology_change(b)
-            topology_changed = True
+            changed_buildings.append(b)
 
-        if topology_changed:
+        if changed_buildings:
             self._notify_bc_topology_change(
                 observation_names=observation_names,
                 action_names=action_names,
                 action_space=action_space,
                 observation_space=observation_space,
                 metadata=metadata,
+                changed_buildings=changed_buildings,
             )
 
     def set_observation_context(
@@ -527,6 +528,7 @@ class AgentTransformerPPO(BaseAgent):
         action_space: List[Any],
         observation_space: List[Any],
         metadata: Optional[Dict[str, Any]],
+        changed_buildings: Optional[List[int]] = None,
     ) -> None:
         if self._bc is None:
             return
@@ -536,6 +538,7 @@ class AgentTransformerPPO(BaseAgent):
             action_space=action_space,
             observation_space=observation_space,
             metadata=metadata,
+            changed_buildings=changed_buildings,
         )
 
     def _build_one_per_building_state(

--- a/algorithms/agents/agent_transformer_ppo.py
+++ b/algorithms/agents/agent_transformer_ppo.py
@@ -129,6 +129,7 @@ class AgentTransformerPPO(BaseAgent):
         self._layout_builder = EntityTokenLayoutBuilder(self._tokenizer_config)
         self._per_building: List[_PerBuildingState] = []
         self._bc = BehaviorCloningRegularizer.from_config(algo, self.config)
+        self.requires_raw_observation_context = bool(self._bc is not None)
         self._latest_raw_observations: Optional[List[npt.NDArray[np.float64]]] = None
         self._latest_encoded_observations: Optional[List[npt.NDArray[np.float64]]] = None
         self._latest_global_learning_step = 0

--- a/algorithms/agents/ppo_agents.py
+++ b/algorithms/agents/ppo_agents.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import random
-from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -16,6 +15,7 @@ from algorithms.agents.base_agent import BaseAgent
 from algorithms.agents.maddpg_agent import ActionScaledActor, _log_torch_runtime, _select_torch_device
 from algorithms.constants import DEFAULT_ONNX_OPSET
 from algorithms.utils.networks import GaussianActor, ValueNetwork
+from algorithms.utils.warm_start_policy import build_warm_start_policy
 from utils.artifact_config_builder import build_auto_artifact_config
 
 
@@ -307,43 +307,16 @@ class _PPOBase(BaseAgent):
         if not self.warm_start_policy_name:
             return
 
-        from algorithms.agents.baseline_policies import (  # Local import avoids registry cycles.
-            NormalNoBatteryPolicy,
-            NormalPolicy,
-            RBCBasicPolicy,
-            RBCSmartPolicy,
-            RandomPolicy,
-        )
-        from algorithms.agents.rbc_agent import RuleBasedPolicy
-
-        policy_registry = {
-            "RuleBasedPolicy": RuleBasedPolicy,
-            "RandomPolicy": RandomPolicy,
-            "NormalNoBatteryPolicy": NormalNoBatteryPolicy,
-            "NormalPolicy": NormalPolicy,
-            "RBCBasicPolicy": RBCBasicPolicy,
-            "RBCSmartPolicy": RBCSmartPolicy,
-        }
-        policy_cls = policy_registry.get(str(self.warm_start_policy_name))
-        if policy_cls is None:
-            supported = ", ".join(sorted(policy_registry))
-            raise ValueError(
-                f"Unsupported PPO warm_start_policy '{self.warm_start_policy_name}'. "
-                f"Supported policies: {supported}."
-            )
-
         exploration_cfg = self.config["algorithm"]["exploration"]["params"]
         policy_hyperparams = exploration_cfg.get("warm_start_policy_hyperparameters") or {}
         if not isinstance(policy_hyperparams, dict):
             raise ValueError("PPO warm_start_policy_hyperparameters must be an object when provided.")
 
-        policy_config = deepcopy(self.config)
-        policy_config["algorithm"] = {
-            "name": str(self.warm_start_policy_name),
-            "hyperparameters": dict(policy_hyperparams),
-        }
-        self._warm_start_policy = policy_cls(policy_config)
-        self._warm_start_policy.attach_environment(
+        self._warm_start_policy = build_warm_start_policy(
+            owner_name="PPO",
+            policy_name=str(self.warm_start_policy_name),
+            policy_hyperparameters=policy_hyperparams,
+            config_template=self.config,
             observation_names=observation_names,
             action_names=action_names,
             action_space=action_space,

--- a/algorithms/pipeline.py
+++ b/algorithms/pipeline.py
@@ -54,7 +54,11 @@ class Pipeline(ExecutionUnit):
 
     @property
     def requires_raw_observation_context(self) -> bool:
-        return any(stage.use_raw_observations for stage in self.stages)
+        return any(
+            stage.use_raw_observations
+            or bool(getattr(stage, "requires_raw_observation_context", False))
+            for stage in self.stages
+        )
 
     def _observations_for_stage(self, stage: ExecutionUnit, fallback: Any) -> Any:
         if stage.use_raw_observations and self._raw_observations is not None:
@@ -283,6 +287,14 @@ class Ensemble(ExecutionUnit):
     @property
     def use_raw_observations(self) -> bool:
         return any(agent.use_raw_observations for agent in self.agents)
+
+    @property
+    def requires_raw_observation_context(self) -> bool:
+        return any(
+            agent.use_raw_observations
+            or bool(getattr(agent, "requires_raw_observation_context", False))
+            for agent in self.agents
+        )
 
     # ------------------------------------------------------------------
     # Core loop

--- a/algorithms/registry.py
+++ b/algorithms/registry.py
@@ -170,7 +170,15 @@ def _stage_to_agent_view(global_config: Dict[str, Any], stage_cfg: Dict[str, Any
         "name": stage_cfg["algorithm"],
         "hyperparameters": stage_cfg.get("hyperparameters", {}) or {},
     }
-    for optional_key in ("networks", "replay_buffer", "exploration", "policy", "tokenizer_config_path", "transformer"):
+    for optional_key in (
+        "networks",
+        "replay_buffer",
+        "exploration",
+        "policy",
+        "tokenizer_config_path",
+        "transformer",
+        "behavior_cloning",
+    ):
         if optional_key in stage_cfg and stage_cfg[optional_key] is not None:
             algorithm_block[optional_key] = stage_cfg[optional_key]
     agent_view["algorithm"] = algorithm_block

--- a/algorithms/utils/behavior_cloning.py
+++ b/algorithms/utils/behavior_cloning.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import random
 from copy import deepcopy
 from typing import Any, Dict, List, Mapping, Optional
 
+import numpy as np
+import torch
+
+from algorithms.utils.entity_token_layout import BuildingTokenLayout
 from algorithms.utils.warm_start_policy import build_warm_start_policy
 
 
@@ -48,6 +53,13 @@ class BehaviorCloningRegularizer:
         self.teacher_policy = None
         self.teacher_action_buffers: List[List[Optional[List[float]]]] = []
         self.latest_teacher_actions: Optional[List[List[float]]] = None
+        self.phaseout_step = 0
+        self._latest_bc_effective_weight = 0.0
+        self._latest_bc_loss = 0.0
+        self._latest_bc_weighted_loss = 0.0
+        self._latest_bc_valid_samples = 0.0
+        self._latest_phaseout_probability = 0.0
+        self._latest_phaseout_used = False
 
     @classmethod
     def from_config(
@@ -119,6 +131,155 @@ class BehaviorCloningRegularizer:
             for building_actions in actions
         ]
 
+    def compute_teacher_actions(
+        self, raw_or_encoded_observations: List[np.ndarray]
+    ) -> Optional[List[List[float]]]:
+        if self.teacher_policy is None:
+            self.set_latest_teacher_actions(None)
+            return None
+
+        actions = self.teacher_policy.predict(
+            raw_or_encoded_observations,
+            deterministic=self.deterministic,
+        )
+        normalized = self._copy_actions(actions)
+        if self.noise_scale > 0.0:
+            normalized = self._add_teacher_noise(normalized)
+        self.set_latest_teacher_actions(normalized)
+        return self._copy_actions(self.latest_teacher_actions or [])
+
+    def effective_weight(self, global_learning_step: int) -> float:
+        if self.weight <= 0.0:
+            return 0.0
+        if global_learning_step < self.decay_start_step:
+            return float(self.weight)
+        if self.decay_steps <= 0:
+            return float(self.weight)
+
+        target = min(float(self.weight), float(self.min_weight))
+        progress = min(
+            max(
+                float(global_learning_step - self.decay_start_step)
+                / float(self.decay_steps),
+                0.0,
+            ),
+            1.0,
+        )
+        return float(self.weight + (target - self.weight) * progress)
+
+    def ca_type_weights(
+        self,
+        layout: BuildingTokenLayout,
+        *,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor:
+        weights: List[float] = []
+        for segment in layout.segments:
+            if segment.family != "ca":
+                continue
+            if segment.type_name == "charger":
+                weights.append(float(self.ev_multiplier))
+            elif segment.type_name == "storage":
+                weights.append(float(self.storage_multiplier))
+            else:
+                weights.append(1.0)
+        return torch.tensor(weights[: layout.n_ca], dtype=dtype, device=device)
+
+    def bc_loss_term(
+        self,
+        *,
+        building_idx: int,
+        layout: BuildingTokenLayout,
+        predicted_means: torch.Tensor,
+        step_indices: torch.Tensor,
+        global_learning_step: int,
+    ) -> torch.Tensor:
+        effective_weight = self.effective_weight(global_learning_step)
+        self._latest_bc_effective_weight = float(effective_weight)
+        if effective_weight <= 0.0:
+            self._set_bc_loss_diagnostics(0.0, 0.0, 0.0)
+            return predicted_means.new_tensor(0.0)
+
+        valid_batch_indices: List[int] = []
+        teacher_rows: List[List[float]] = []
+        for batch_idx, step_idx in enumerate(
+            step_indices.detach().cpu().view(-1).tolist()
+        ):
+            teacher_action = self.teacher_action_for(building_idx, int(step_idx))
+            if teacher_action is None or len(teacher_action) != layout.n_ca:
+                continue
+            teacher_array = np.asarray(teacher_action, dtype=np.float32)
+            if (
+                teacher_array.shape != (layout.n_ca,)
+                or not np.isfinite(teacher_array).all()
+            ):
+                continue
+            valid_batch_indices.append(batch_idx)
+            teacher_rows.append(teacher_array.astype(np.float32).tolist())
+
+        valid_samples = float(len(valid_batch_indices))
+        if not valid_batch_indices:
+            self._set_bc_loss_diagnostics(0.0, 0.0, 0.0)
+            return predicted_means.new_tensor(0.0)
+
+        index = torch.as_tensor(
+            valid_batch_indices,
+            dtype=torch.long,
+            device=predicted_means.device,
+        )
+        predicted = predicted_means.index_select(0, index).squeeze(-1)
+        teacher = predicted_means.new_tensor(teacher_rows)
+        ca_weights = self.ca_type_weights(
+            layout,
+            dtype=predicted_means.dtype,
+            device=predicted_means.device,
+        ).view(1, -1)
+        raw_loss = ((predicted - teacher).pow(2) * ca_weights).mean()
+        weighted_loss = raw_loss * float(effective_weight)
+        self._set_bc_loss_diagnostics(
+            float(raw_loss.detach().cpu().item()),
+            float(weighted_loss.detach().cpu().item()),
+            valid_samples,
+        )
+        return weighted_loss
+
+    def maybe_phaseout(
+        self,
+        actor_actions: List[List[float]],
+        deterministic: bool,
+    ) -> List[List[float]]:
+        self._latest_phaseout_probability = 0.0
+        self._latest_phaseout_used = False
+        if deterministic:
+            return actor_actions
+
+        self.phaseout_step += 1
+        if self.latest_teacher_actions is None or self.phaseout_steps <= 0:
+            return actor_actions
+
+        probability = max(
+            0.0,
+            1.0 - float(self.phaseout_step) / float(self.phaseout_steps),
+        )
+        self._latest_phaseout_probability = probability
+        if probability <= 0.0:
+            return actor_actions
+
+        if self.phaseout_mode == "blend":
+            blended = self._blend_actions(
+                actor_actions,
+                self.latest_teacher_actions,
+                probability,
+            )
+            self._latest_phaseout_used = blended is not actor_actions
+            return blended
+
+        if random.random() < probability:
+            self._latest_phaseout_used = True
+            return self._copy_actions(self.latest_teacher_actions)
+        return actor_actions
+
     def record_transition(self, building_idx: int) -> None:
         buffer = self._buffer_for(building_idx)
         if (
@@ -174,12 +335,71 @@ class BehaviorCloningRegularizer:
             "behavior_cloning_teacher_buffer_size": float(
                 sum(len(buffer) for buffer in self.teacher_action_buffers)
             ),
+            "behavior_cloning_effective_weight": float(self._latest_bc_effective_weight),
+            "behavior_cloning_loss": float(self._latest_bc_loss),
+            "behavior_cloning_weighted_loss": float(self._latest_bc_weighted_loss),
+            "behavior_cloning_valid_samples": float(self._latest_bc_valid_samples),
+            "behavior_cloning_phaseout_probability": float(
+                self._latest_phaseout_probability
+            ),
+            "behavior_cloning_phaseout_used": float(self._latest_phaseout_used),
         }
 
     def _buffer_for(self, building_idx: int) -> List[Optional[List[float]]]:
         if building_idx < 0 or building_idx >= len(self.teacher_action_buffers):
             raise IndexError(f"Building index {building_idx} is out of range.")
         return self.teacher_action_buffers[building_idx]
+
+    def _add_teacher_noise(self, actions: List[List[float]]) -> List[List[float]]:
+        noisy: List[List[float]] = []
+        for building_actions in actions:
+            values = np.asarray(building_actions, dtype=np.float32)
+            noise = np.random.normal(0.0, self.noise_scale, size=values.shape)
+            noisy.append(
+                np.clip(values + noise, -1.0, 1.0).astype(np.float32).tolist()
+            )
+        return noisy
+
+    def _blend_actions(
+        self,
+        actor_actions: List[List[float]],
+        teacher_actions: List[List[float]],
+        probability: float,
+    ) -> List[List[float]]:
+        blended: List[List[float]] = []
+        used_teacher = False
+        for building_idx, actor_building_actions in enumerate(actor_actions):
+            if building_idx >= len(teacher_actions):
+                blended.append(actor_building_actions)
+                continue
+            actor = np.asarray(actor_building_actions, dtype=np.float32)
+            teacher = np.asarray(teacher_actions[building_idx], dtype=np.float32)
+            if actor.shape != teacher.shape:
+                blended.append(actor_building_actions)
+                continue
+            values = probability * teacher + (1.0 - probability) * actor
+            blended.append(np.clip(values, -1.0, 1.0).astype(np.float32).tolist())
+            used_teacher = True
+        if not used_teacher:
+            return actor_actions
+        return blended
+
+    def _set_bc_loss_diagnostics(
+        self,
+        raw_loss: float,
+        weighted_loss: float,
+        valid_samples: float,
+    ) -> None:
+        self._latest_bc_loss = float(raw_loss)
+        self._latest_bc_weighted_loss = float(weighted_loss)
+        self._latest_bc_valid_samples = float(valid_samples)
+
+    @staticmethod
+    def _copy_actions(actions: List[List[float]]) -> List[List[float]]:
+        return [
+            [float(value) for value in building_actions]
+            for building_actions in actions
+        ]
 
 
 __all__ = ["BehaviorCloningRegularizer"]

--- a/algorithms/utils/behavior_cloning.py
+++ b/algorithms/utils/behavior_cloning.py
@@ -276,8 +276,12 @@ class BehaviorCloningRegularizer:
             return blended
 
         if random.random() < probability:
-            self._latest_phaseout_used = True
-            return self._copy_actions(self.latest_teacher_actions)
+            actions = self._replace_compatible_actions(
+                actor_actions,
+                self.latest_teacher_actions,
+            )
+            self._latest_phaseout_used = actions is not actor_actions
+            return actions
         return actor_actions
 
     def record_transition(self, building_idx: int) -> None:
@@ -383,6 +387,27 @@ class BehaviorCloningRegularizer:
         if not used_teacher:
             return actor_actions
         return blended
+
+    def _replace_compatible_actions(
+        self,
+        actor_actions: List[List[float]],
+        teacher_actions: List[List[float]],
+    ) -> List[List[float]]:
+        replaced: List[List[float]] = []
+        used_teacher = False
+        for building_idx, actor_building_actions in enumerate(actor_actions):
+            if building_idx >= len(teacher_actions):
+                replaced.append(actor_building_actions)
+                continue
+            teacher_building_actions = teacher_actions[building_idx]
+            if len(teacher_building_actions) != len(actor_building_actions):
+                replaced.append(actor_building_actions)
+                continue
+            replaced.append([float(value) for value in teacher_building_actions])
+            used_teacher = True
+        if not used_teacher:
+            return actor_actions
+        return replaced
 
     def _set_bc_loss_diagnostics(
         self,

--- a/algorithms/utils/behavior_cloning.py
+++ b/algorithms/utils/behavior_cloning.py
@@ -235,7 +235,9 @@ class BehaviorCloningRegularizer:
             dtype=predicted_means.dtype,
             device=predicted_means.device,
         ).view(1, -1)
-        raw_loss = ((predicted - teacher).pow(2) * ca_weights).mean()
+        weighted_error = (predicted - teacher).pow(2) * ca_weights
+        denominator = ca_weights.expand_as(predicted).sum().clamp_min(1.0)
+        raw_loss = weighted_error.sum() / denominator
         weighted_loss = raw_loss * float(effective_weight)
         self._set_bc_loss_diagnostics(
             float(raw_loss.detach().cpu().item()),

--- a/algorithms/utils/behavior_cloning.py
+++ b/algorithms/utils/behavior_cloning.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import random
 from copy import deepcopy
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, Iterable, List, Mapping, Optional
 
 import numpy as np
 import torch
@@ -107,11 +107,7 @@ class BehaviorCloningRegularizer:
         observation_space: List[Any],
         metadata: Optional[Dict[str, Any]],
     ) -> None:
-        self.teacher_policy = build_warm_start_policy(
-            owner_name="AgentTransformerPPO",
-            policy_name=self.policy,
-            policy_hyperparameters=self.hyperparameters,
-            config_template=self.agent_config_template,
+        self.teacher_policy = self._build_teacher_policy(
             observation_names=observation_names,
             action_names=action_names,
             action_space=action_space,
@@ -321,16 +317,28 @@ class BehaviorCloningRegularizer:
         action_space: List[Any],
         observation_space: List[Any],
         metadata: Optional[Dict[str, Any]],
+        changed_buildings: Optional[Iterable[int]] = None,
     ) -> None:
-        self.teacher_action_buffers = []
         self.latest_teacher_actions = None
-        self.attach_environment(
+        previous_buffers = self.teacher_action_buffers
+        self.teacher_policy = self._build_teacher_policy(
             observation_names=observation_names,
             action_names=action_names,
             action_space=action_space,
             observation_space=observation_space,
             metadata=metadata,
         )
+        if changed_buildings is None:
+            self.teacher_action_buffers = [[] for _ in observation_names]
+            return
+
+        changed = {int(idx) for idx in changed_buildings}
+        self.teacher_action_buffers = [
+            []
+            if idx in changed or idx >= len(previous_buffers)
+            else self._copy_buffer(previous_buffers[idx])
+            for idx in range(len(observation_names))
+        ]
 
     def snapshot_metrics(self) -> Dict[str, float]:
         return {
@@ -355,6 +363,33 @@ class BehaviorCloningRegularizer:
         if building_idx < 0 or building_idx >= len(self.teacher_action_buffers):
             raise IndexError(f"Building index {building_idx} is out of range.")
         return self.teacher_action_buffers[building_idx]
+
+    def _build_teacher_policy(
+        self,
+        *,
+        observation_names: List[List[str]],
+        action_names: List[List[str]],
+        action_space: List[Any],
+        observation_space: List[Any],
+        metadata: Optional[Dict[str, Any]],
+    ):
+        return build_warm_start_policy(
+            owner_name="AgentTransformerPPO",
+            policy_name=self.policy,
+            policy_hyperparameters=self.hyperparameters,
+            config_template=self.agent_config_template,
+            observation_names=observation_names,
+            action_names=action_names,
+            action_space=action_space,
+            observation_space=observation_space,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _copy_buffer(
+        buffer: List[Optional[List[float]]],
+    ) -> List[Optional[List[float]]]:
+        return [None if action is None else list(action) for action in buffer]
 
     def _add_teacher_noise(self, actions: List[List[float]]) -> List[List[float]]:
         noisy: List[List[float]] = []

--- a/algorithms/utils/behavior_cloning.py
+++ b/algorithms/utils/behavior_cloning.py
@@ -1,0 +1,185 @@
+"""Behavior-cloning support utilities for Transformer PPO."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, List, Mapping, Optional
+
+from algorithms.utils.warm_start_policy import build_warm_start_policy
+
+
+class BehaviorCloningRegularizer:
+    """Lifecycle and teacher-action buffer core for behavior cloning."""
+
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        weight: float,
+        min_weight: float,
+        decay_start_step: int,
+        decay_steps: int,
+        ev_multiplier: float,
+        storage_multiplier: float,
+        policy: str,
+        deterministic: bool,
+        noise_scale: float,
+        phaseout_steps: int,
+        phaseout_mode: str,
+        hyperparameters: Mapping[str, Any],
+        agent_config_template: Mapping[str, Any],
+    ) -> None:
+        self.enabled = enabled
+        self.weight = weight
+        self.min_weight = min_weight
+        self.decay_start_step = decay_start_step
+        self.decay_steps = decay_steps
+        self.ev_multiplier = ev_multiplier
+        self.storage_multiplier = storage_multiplier
+
+        self.policy = policy
+        self.deterministic = deterministic
+        self.noise_scale = noise_scale
+        self.phaseout_steps = phaseout_steps
+        self.phaseout_mode = phaseout_mode
+        self.hyperparameters = deepcopy(dict(hyperparameters))
+        self.agent_config_template = deepcopy(dict(agent_config_template))
+
+        self.teacher_policy = None
+        self.teacher_action_buffers: List[List[Optional[List[float]]]] = []
+        self.latest_teacher_actions: Optional[List[List[float]]] = None
+
+    @classmethod
+    def from_config(
+        cls,
+        algorithm_cfg: Mapping[str, Any],
+        agent_config_template: Mapping[str, Any],
+    ) -> Optional["BehaviorCloningRegularizer"]:
+        behavior_cloning = algorithm_cfg.get("behavior_cloning")
+        if not isinstance(behavior_cloning, Mapping):
+            return None
+        if not bool(behavior_cloning.get("enabled", False)):
+            return None
+
+        warm_start = behavior_cloning.get("warm_start")
+        if not isinstance(warm_start, Mapping):
+            return None
+
+        policy = warm_start.get("policy")
+        if not policy:
+            return None
+
+        return cls(
+            enabled=True,
+            weight=float(behavior_cloning.get("weight", 0.0)),
+            min_weight=float(behavior_cloning.get("min_weight", 0.0)),
+            decay_start_step=int(behavior_cloning.get("decay_start_step", 0)),
+            decay_steps=int(behavior_cloning.get("decay_steps", 0)),
+            ev_multiplier=float(behavior_cloning.get("ev_multiplier", 1.0)),
+            storage_multiplier=float(behavior_cloning.get("storage_multiplier", 1.0)),
+            policy=str(policy),
+            deterministic=bool(warm_start.get("deterministic", True)),
+            noise_scale=float(warm_start.get("noise_scale", 0.0)),
+            phaseout_steps=int(warm_start.get("phaseout_steps", 0)),
+            phaseout_mode=str(warm_start.get("phaseout_mode", "probability")),
+            hyperparameters=warm_start.get("hyperparameters") or {},
+            agent_config_template=agent_config_template,
+        )
+
+    def attach_environment(
+        self,
+        *,
+        observation_names: List[List[str]],
+        action_names: List[List[str]],
+        action_space: List[Any],
+        observation_space: List[Any],
+        metadata: Optional[Dict[str, Any]],
+    ) -> None:
+        self.teacher_policy = build_warm_start_policy(
+            owner_name="AgentTransformerPPO",
+            policy_name=self.policy,
+            policy_hyperparameters=self.hyperparameters,
+            config_template=self.agent_config_template,
+            observation_names=observation_names,
+            action_names=action_names,
+            action_space=action_space,
+            observation_space=observation_space,
+            metadata=metadata,
+        )
+        self.teacher_action_buffers = [[] for _ in observation_names]
+
+    def set_latest_teacher_actions(
+        self, actions: Optional[List[List[float]]]
+    ) -> None:
+        if actions is None:
+            self.latest_teacher_actions = None
+            return
+        self.latest_teacher_actions = [
+            [float(value) for value in building_actions]
+            for building_actions in actions
+        ]
+
+    def record_transition(self, building_idx: int) -> None:
+        buffer = self._buffer_for(building_idx)
+        if (
+            self.latest_teacher_actions is None
+            or building_idx >= len(self.latest_teacher_actions)
+        ):
+            buffer.append(None)
+            return
+        buffer.append(list(self.latest_teacher_actions[building_idx]))
+
+    def teacher_action_for(
+        self, building_idx: int, step_idx: int
+    ) -> Optional[List[float]]:
+        if building_idx < 0 or building_idx >= len(self.teacher_action_buffers):
+            return None
+        buffer = self.teacher_action_buffers[building_idx]
+        if step_idx < 0 or step_idx >= len(buffer):
+            return None
+        action = buffer[step_idx]
+        if action is None:
+            return None
+        return list(action)
+
+    def on_buffer_flushed(self, building_idx: int) -> None:
+        if 0 <= building_idx < len(self.teacher_action_buffers):
+            self.teacher_action_buffers[building_idx].clear()
+
+    def on_topology_change(
+        self,
+        *,
+        observation_names: List[List[str]],
+        action_names: List[List[str]],
+        action_space: List[Any],
+        observation_space: List[Any],
+        metadata: Optional[Dict[str, Any]],
+    ) -> None:
+        self.teacher_action_buffers = []
+        self.latest_teacher_actions = None
+        self.attach_environment(
+            observation_names=observation_names,
+            action_names=action_names,
+            action_space=action_space,
+            observation_space=observation_space,
+            metadata=metadata,
+        )
+
+    def snapshot_metrics(self) -> Dict[str, float]:
+        return {
+            "behavior_cloning_teacher_enabled": float(self.teacher_policy is not None),
+            "behavior_cloning_latest_teacher_available": float(
+                self.latest_teacher_actions is not None
+            ),
+            "behavior_cloning_teacher_buffer_size": float(
+                sum(len(buffer) for buffer in self.teacher_action_buffers)
+            ),
+        }
+
+    def _buffer_for(self, building_idx: int) -> List[Optional[List[float]]]:
+        if building_idx < 0 or building_idx >= len(self.teacher_action_buffers):
+            raise IndexError(f"Building index {building_idx} is out of range.")
+        return self.teacher_action_buffers[building_idx]
+
+
+__all__ = ["BehaviorCloningRegularizer"]

--- a/algorithms/utils/ppo_components.py
+++ b/algorithms/utils/ppo_components.py
@@ -148,6 +148,7 @@ class Batch:
     advantages: torch.Tensor
     returns: torch.Tensor
     values: torch.Tensor
+    step_indices: torch.Tensor
 
 
 class RolloutBuffer:
@@ -268,6 +269,7 @@ class RolloutBuffer:
                 advantages=self.advantages[batch_indices],
                 returns=self.returns[batch_indices],
                 values=torch.stack([self.values[i].squeeze() for i in batch_indices]),
+                step_indices=batch_indices.detach().clone().long(),
             )
 
     def clear(self) -> None:

--- a/algorithms/utils/warm_start_policy.py
+++ b/algorithms/utils/warm_start_policy.py
@@ -1,0 +1,73 @@
+"""Shared helpers for constructing warm-start teacher policies."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, List, Mapping, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from algorithms.agents.base_agent import BaseAgent
+
+
+def build_warm_start_policy(
+    *,
+    owner_name: str,
+    policy_name: str,
+    policy_hyperparameters: Mapping[str, Any] | None,
+    config_template: Mapping[str, Any],
+    observation_names: List[List[str]],
+    action_names: List[List[str]],
+    action_space: List[Any],
+    observation_space: List[Any],
+    metadata: Optional[Dict[str, Any]],
+) -> BaseAgent:
+    from algorithms.agents.baseline_policies import (  # Local import avoids registry cycles.
+        NormalNoBatteryPolicy,
+        NormalPolicy,
+        RBCBasicPolicy,
+        RBCCommunityPolicy,
+        RBCSmartPolicy,
+        RandomPolicy,
+    )
+    from algorithms.agents.rbc_agent import RuleBasedPolicy
+
+    policy_registry = {
+        "RuleBasedPolicy": RuleBasedPolicy,
+        "RandomPolicy": RandomPolicy,
+        "NormalNoBatteryPolicy": NormalNoBatteryPolicy,
+        "NormalPolicy": NormalPolicy,
+        "RBCBasicPolicy": RBCBasicPolicy,
+        "RBCCommunityPolicy": RBCCommunityPolicy,
+        "RBCSmartPolicy": RBCSmartPolicy,
+    }
+
+    policy_cls = policy_registry.get(policy_name)
+    if policy_cls is None:
+        supported = ", ".join(sorted(policy_registry))
+        raise ValueError(
+            f"Unsupported {owner_name} warm-start policy '{policy_name}'. "
+            f"Supported policies: {supported}."
+        )
+
+    if policy_hyperparameters is not None and not isinstance(policy_hyperparameters, Mapping):
+        raise ValueError(
+            f"{owner_name} warm-start policy '{policy_name}' hyperparameters must be a mapping when provided."
+        )
+
+    config = deepcopy(dict(config_template))
+    config["algorithm"] = {
+        "name": policy_name,
+        "hyperparameters": dict(policy_hyperparameters or {}),
+    }
+    policy = policy_cls(config)
+    policy.attach_environment(
+        observation_names=observation_names,
+        action_names=action_names,
+        action_space=action_space,
+        observation_space=observation_space,
+        metadata=metadata,
+    )
+    return policy
+
+
+__all__ = ["build_warm_start_policy"]

--- a/configs/templates/dynamic/transformer_ppo_bc_entity_dynamic.yaml
+++ b/configs/templates/dynamic/transformer_ppo_bc_entity_dynamic.yaml
@@ -1,0 +1,128 @@
+# Local AgentTransformerPPO template for entity interface with dynamic asset-only events and behavior cloning.
+# Smoke-tested by tests/test_template_transformer_ppo_bc_entity_dynamic.py.
+
+metadata:
+  experiment_name: "transformer_ppo_bc_entity_dynamic_assets_only_template"
+  run_name: "Transformer PPO BC Entity Dynamic Assets-Only Local"
+  community_name: "default_community"
+  description: "Per-building Transformer + PPO over the entity interface with RBC behavior cloning; assets-only dynamic topology"
+
+runtime:
+  log_dir: null
+  job_dir: null
+  mlflow_uri: null
+  job_id: null
+  run_id: null
+  run_name: null
+  tracking_uri: null
+  experiment_id: null
+  mlflow_run_url: null
+
+tracking:
+  mlflow_enabled: true
+  log_level: "INFO"
+  log_frequency: 1
+  mlflow_step_sample_interval: 10
+  mlflow_artifacts_profile: minimal
+  progress_updates_enabled: true
+  progress_update_interval: 5
+  system_metrics_enabled: false
+  system_metrics_interval: 10
+
+checkpointing:
+  resume_training: false
+  checkpoint_run_id: null
+  checkpoint_artifact: "transformer_ppo_checkpoint.pt"
+  use_best_checkpoint_artifact: false
+  reset_replay_buffer: false
+  freeze_pretrained_layers: false
+  fine_tune: false
+  checkpoint_interval: 1
+  require_update_step: true
+  require_initial_exploration_done: true
+
+bundle:
+  bundle_version: null
+  description: null
+  alias_mapping_path: null
+  require_observations_envelope: false
+  artifact_config: {}
+  per_agent_artifact_config: {}
+
+simulator:
+  dataset_name: citylearn_three_phase_dynamic_assets_only_demo_15s_parquet
+  dataset_path: ./datasets/citylearn_three_phase_dynamic_assets_only_demo_15s_parquet/schema.json
+  central_agent: false
+  interface: entity
+  topology_mode: dynamic
+  entity_encoding:
+    enabled: true
+    normalization: minmax_space
+    clip: true
+  reward_function: CostHardConstraintReward
+  reward_function_kwargs:
+    squash: 1   # tanh-squash rewards to [-1, 1] to prevent PPO gradient explosion
+  episodes: 26  # ~6.5h based on ~15min/episode observed in my_test_run
+  simulation_start_time_step: 0
+  simulation_end_time_step: 3400
+  episode_time_steps: 3401
+  export:
+    mode: end
+    export_kpis_on_episode_end: true
+    session_name: null
+  wrapper_reward:
+    enabled: false
+    profile: cost_limits_v1
+    clip_enabled: true
+    clip_min: -10.0
+    clip_max: 10.0
+    squash: none
+
+training:
+  seed: 7
+  steps_between_training_updates: 256  # PPO is on-policy: collect a real trajectory before each update. Must be >= minibatch_size.
+  target_update_interval: 0  # PPO doesn't use a target net; preserved for schema parity
+
+topology:
+  num_agents: null
+  observation_dimensions: null
+  action_dimensions: null
+  action_space: null
+
+pipeline:
+  - algorithm: "AgentTransformerPPO"
+    count: 1
+    tokenizer_config_path: "configs/tokenizers/entity_default.json"
+    transformer:
+      d_model: 64
+      nhead: 4
+      num_layers: 2
+      dim_feedforward: 128
+      dropout: 0.1
+    hyperparameters:
+      learning_rate: 2.0e-4
+      gamma: 0.99
+      gae_lambda: 0.95
+      clip_eps: 0.2
+      ppo_epochs: 4
+      minibatch_size: 64
+      entropy_coeff: 0.03
+      value_coeff: 0.5
+      max_grad_norm: 1.0
+    behavior_cloning:
+      enabled: true
+      weight: 0.42
+      min_weight: 0.24
+      decay_start_step: 512
+      decay_steps: 3584
+      ev_multiplier: 24.0
+      storage_multiplier: 0.18
+      warm_start:
+        policy: RBCCommunityPolicy
+        deterministic: true
+        noise_scale: 0.0
+        phaseout_steps: 6144
+        phaseout_mode: blend
+        hyperparameters: {}
+
+execution: null

--- a/docs/superpowers/plans/2026-07-05-tppo-behavior-cloning.md
+++ b/docs/superpowers/plans/2026-07-05-tppo-behavior-cloning.md
@@ -1,0 +1,438 @@
+# TransformerPPO Behavior Cloning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add optional Behavior Cloning (BC) and warm-start-action phaseout to `AgentTransformerPPO`, using `RBCCommunityPolicy` as the default teacher, while keeping the existing agent clean and avoiding BC-specific pollution in shared PPO components.
+
+**Architecture:** Implement BC as a `BehaviorCloningRegularizer` collaborator in `algorithms/utils/behavior_cloning.py`. The collaborator owns the teacher policy, teacher-action buffers, BC loss, CA-type weights, weight schedule, phaseout logic, and diagnostics. `AgentTransformerPPO` receives only small lifecycle hook calls, and BC is disabled by omitting the optional `behavior_cloning` config block.
+
+**Tech Stack:** Python, PyTorch, existing entity-interface Transformer PPO modules, existing RBC baseline policies.
+
+---
+
+## File Structure
+
+- Modify: `algorithms/utils/ppo_components.py`
+  - Add `Batch.step_indices` as a general-purpose minibatch transition-index field.
+- Create: `algorithms/utils/warm_start_policy.py`
+  - Shared helper to instantiate and attach warm-start teacher policies.
+- Create: `algorithms/utils/behavior_cloning.py`
+  - BC collaborator that encapsulates all teacher, phaseout, BC-loss, and diagnostics state.
+- Modify: `algorithms/agents/ppo_agents.py`
+  - Replace private warm-start-policy construction with the shared helper while preserving behavior.
+- Modify: `algorithms/agents/agent_transformer_ppo.py`
+  - Add minimal collaborator hooks.
+- Modify: `utils/config_schema.py`
+  - Add optional `behavior_cloning` schema for `AgentTransformerPPO` pipeline stages.
+- Create: `configs/templates/dynamic/transformer_ppo_bc_entity_dynamic.yaml`
+  - BC-enabled dynamic entity template.
+- Create/modify tests:
+  - `tests/test_ppo_components.py`
+  - `tests/test_warm_start_policy.py`
+  - `tests/test_behavior_cloning_regularizer.py`
+  - `tests/test_agent_transformer_ppo_behavior_cloning.py`
+  - `tests/test_template_transformer_ppo_bc_entity_dynamic.py`
+  - Existing schema and PPO tests as needed.
+- Modify docs:
+  - `docs/transformer_ppo_spec.md`
+  - `AGENTS.md`
+
+---
+
+### Task 1: Worktree Baseline and Plan Artifact
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-07-05-tppo-behavior-cloning.md`
+
+- [ ] **Step 1: Verify branch/worktree**
+
+Run: `git branch --show-current && git status --short`
+
+Expected: branch is `gj/tppo_bclonning`; status is clean except the plan artifact being added.
+
+- [ ] **Step 2: Run targeted baseline tests**
+
+Run: `pytest tests/test_agent_transformer_ppo.py tests/test_agent_transformer_ppo_wrapper_integration.py tests/test_ppo_components.py -q`
+
+Expected: all tests pass before feature work begins.
+
+- [ ] **Step 3: Commit plan artifact**
+
+Run: `git add docs/superpowers/plans/2026-07-05-tppo-behavior-cloning.md && git commit -m "docs: plan TransformerPPO behavior cloning"`
+
+---
+
+### Task 2: Add Batch Step Indices
+
+**Files:**
+- Modify: `algorithms/utils/ppo_components.py`
+- Test: `tests/test_ppo_components.py`
+
+- [ ] **Step 1: Write failing test**
+
+Add a test to `tests/test_ppo_components.py` verifying `RolloutBuffer.get_batches(...)` yields `Batch.step_indices` and that each row maps back to the original stored observation/action.
+
+```python
+def test_rollout_buffer_batches_include_original_step_indices():
+    import torch
+    from algorithms.utils.ppo_components import RolloutBuffer
+
+    buffer = RolloutBuffer(gamma=0.99, gae_lambda=0.95)
+    for idx in range(5):
+        buffer.add(
+            observation=torch.tensor([float(idx)]),
+            action=torch.tensor([[float(idx)]]),
+            log_prob=torch.tensor([0.0]),
+            reward=0.0,
+            value=torch.tensor([0.0]),
+            done=False,
+        )
+    buffer.compute_returns_and_advantages(torch.tensor([0.0]))
+
+    seen = []
+    for batch in buffer.get_batches(batch_size=2):
+        assert batch.step_indices.dtype == torch.long
+        assert batch.step_indices.shape[0] == batch.observations.shape[0]
+        for row, original_idx in enumerate(batch.step_indices.tolist()):
+            assert batch.observations[row, 0].item() == float(original_idx)
+            assert batch.actions[row, 0, 0].item() == float(original_idx)
+            seen.append(original_idx)
+
+    assert sorted(seen) == [0, 1, 2, 3, 4]
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pytest tests/test_ppo_components.py::test_rollout_buffer_batches_include_original_step_indices -v`
+
+Expected: FAIL because `Batch` has no `step_indices` field.
+
+- [ ] **Step 3: Implement minimal change**
+
+In `algorithms/utils/ppo_components.py`, add `step_indices: torch.Tensor` to the `Batch` dataclass and pass `batch_indices.detach().clone()` in `RolloutBuffer.get_batches(...)`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `pytest tests/test_ppo_components.py::test_rollout_buffer_batches_include_original_step_indices tests/test_ppo_components.py -q`
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add algorithms/utils/ppo_components.py tests/test_ppo_components.py && git commit -m "feat(ppo): expose rollout batch step indices"`
+
+---
+
+### Task 3: Shared Warm-Start Policy Helper
+
+**Files:**
+- Create: `algorithms/utils/warm_start_policy.py`
+- Create: `tests/test_warm_start_policy.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create tests for:
+- Building `RBCCommunityPolicy` by name and attaching it.
+- Passing `warm_start_policy_hyperparameters` into the teacher config.
+- Unsupported policy names raising a clear `ValueError` listing supported names.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pytest tests/test_warm_start_policy.py -v`
+
+Expected: FAIL because `algorithms.utils.warm_start_policy` does not exist.
+
+- [ ] **Step 3: Implement helper**
+
+Create `build_warm_start_policy(...)` with this public shape:
+
+```python
+def build_warm_start_policy(
+    *,
+    owner_name: str,
+    policy_name: str,
+    policy_hyperparameters: Mapping[str, Any] | None,
+    config_template: Mapping[str, Any],
+    observation_names: List[List[str]],
+    action_names: List[List[str]],
+    action_space: List[Any],
+    observation_space: List[Any],
+    metadata: Optional[Dict[str, Any]],
+) -> BaseAgent:
+    ...
+```
+
+Supported policies: `RuleBasedPolicy`, `RandomPolicy`, `NormalNoBatteryPolicy`, `NormalPolicy`, `RBCBasicPolicy`, `RBCSmartPolicy`, `RBCCommunityPolicy`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `pytest tests/test_warm_start_policy.py -q`
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add algorithms/utils/warm_start_policy.py tests/test_warm_start_policy.py && git commit -m "feat(utils): share warm-start policy builder"`
+
+---
+
+### Task 4: Migrate Existing PPO Warm-Start Initialization
+
+**Files:**
+- Modify: `algorithms/agents/ppo_agents.py`
+- Test: existing PPO and warm-start policy tests.
+
+- [ ] **Step 1: Write characterization test if missing**
+
+If no existing test covers `_PPOBase._initialize_warm_start_policy`, add one that instantiates `IPPO` or `MAPPO` with `warm_start_policy: RBCSmartPolicy`, calls `attach_environment`, and asserts `_warm_start_policy` is populated.
+
+- [ ] **Step 2: Verify RED only if adding new characterization**
+
+If adding the test before migration, it should pass on current code. This is a characterization refactor exception; do not require failure because behavior already exists.
+
+- [ ] **Step 3: Replace implementation**
+
+In `_PPOBase._initialize_warm_start_policy`, replace the local imports/registry/config-copy/attach logic with `build_warm_start_policy(...)`. Keep method signature and error message owner prefix as `PPO`.
+
+- [ ] **Step 4: Verify**
+
+Run: `pytest tests/test_warm_start_policy.py tests/test_ppo_agents.py -q` if `tests/test_ppo_agents.py` exists; otherwise run the PPO-related tests available in the repo.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add algorithms/agents/ppo_agents.py tests && git commit -m "refactor(ppo): use shared warm-start policy builder"`
+
+---
+
+### Task 5: Config Schema for TransformerPPO BC
+
+**Files:**
+- Modify: `utils/config_schema.py`
+- Test: schema tests.
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests verifying `TransformerPPOStageConfig` accepts:
+
+```yaml
+behavior_cloning:
+  enabled: true
+  weight: 0.42
+  min_weight: 0.24
+  decay_start_step: 512
+  decay_steps: 3584
+  ev_multiplier: 24.0
+  storage_multiplier: 0.18
+  warm_start:
+    policy: RBCCommunityPolicy
+    deterministic: true
+    noise_scale: 0.0
+    phaseout_steps: 6144
+    phaseout_mode: blend
+    hyperparameters: {}
+```
+
+Also add a rejection test for invalid `phaseout_mode`.
+
+- [ ] **Step 2: Verify RED**
+
+Run the schema test selection. Expected failure: extra/unknown `behavior_cloning` field.
+
+- [ ] **Step 3: Implement schema**
+
+Add `TransformerPPOWarmStartConfig` and `TransformerPPOBehaviorCloningConfig`, then add `behavior_cloning: Optional[TransformerPPOBehaviorCloningConfig] = None` to `TransformerPPOStageConfig`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run schema tests.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add utils/config_schema.py tests && git commit -m "feat(config): add TransformerPPO behavior cloning schema"`
+
+---
+
+### Task 6: BehaviorCloningRegularizer Lifecycle Core
+
+**Files:**
+- Create: `algorithms/utils/behavior_cloning.py`
+- Create: `tests/test_behavior_cloning_regularizer.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Tests should cover:
+- `from_config(...)` returns `None` when config absent or disabled.
+- `from_config(...)` returns an instance when enabled and warm_start is present.
+- `attach_environment(...)` builds the teacher with the shared helper.
+- `record_transition(building_idx)` appends the latest teacher action into a per-building deque.
+- `on_buffer_flushed(building_idx)` clears only that building's deque.
+- `on_topology_change(...)` clears all deques and re-attaches the teacher.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pytest tests/test_behavior_cloning_regularizer.py -v`
+
+Expected: module missing.
+
+- [ ] **Step 3: Implement lifecycle core**
+
+Use one class. Keep dependencies small: standard typing, `collections.deque`, `copy.deepcopy`, `numpy`, `torch`, `build_warm_start_policy`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `pytest tests/test_behavior_cloning_regularizer.py -q`
+
+Expected: lifecycle tests pass.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add algorithms/utils/behavior_cloning.py tests/test_behavior_cloning_regularizer.py && git commit -m "feat(tppo): add BC regularizer lifecycle core"`
+
+---
+
+### Task 7: BC Loss, Type Weights, Schedule, and Phaseout
+
+**Files:**
+- Modify: `algorithms/utils/behavior_cloning.py`
+- Test: `tests/test_behavior_cloning_regularizer.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Tests should cover:
+- Effective weight schedule: base before start, linear decay, min after end.
+- Per-CA-type weights from layout segments: `charger -> ev_multiplier`, `storage -> storage_multiplier`, default `1.0`.
+- BC loss is zero when predicted equals teacher.
+- BC loss ignores missing/NaN teacher actions.
+- `probability` phaseout can return teacher actions.
+- `blend` phaseout returns `p * teacher + (1-p) * actor` and decays over predict steps.
+- Deterministic prediction disables phaseout but still allows teacher cache for BC.
+
+- [ ] **Step 2: Verify RED**
+
+Run the new tests; expected failures are missing methods.
+
+- [ ] **Step 3: Implement methods**
+
+Add:
+
+```python
+effective_weight(global_learning_step: int) -> float
+ca_type_weights(layout: BuildingTokenLayout, *, dtype, device) -> torch.Tensor
+bc_loss_term(...)
+compute_teacher_actions(...)
+maybe_phaseout(...)
+snapshot_metrics() -> Dict[str, float]
+```
+
+BC loss uses finite masks and denominator `clamp(weights.sum(), min=1.0)`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `pytest tests/test_behavior_cloning_regularizer.py -q`
+
+- [ ] **Step 5: Commit**
+
+Run: `git add algorithms/utils/behavior_cloning.py tests/test_behavior_cloning_regularizer.py && git commit -m "feat(tppo): implement BC loss and warm-start phaseout"`
+
+---
+
+### Task 8: Wire Collaborator Into AgentTransformerPPO
+
+**Files:**
+- Modify: `algorithms/agents/agent_transformer_ppo.py`
+- Create: `tests/test_agent_transformer_ppo_behavior_cloning.py`
+
+- [ ] **Step 1: Write failing integration tests**
+
+Tests should cover:
+- `AgentTransformerPPO(...without behavior_cloning...)` has `_bc is None` and existing predict/update still work.
+- With BC config, `_bc` exists after init and its teacher exists after `attach_environment`.
+- `predict(...)` computes teacher actions and phaseout can blend.
+- `update(...)` calls `record_transition` so teacher deques align with buffer length.
+- PPO update adds a finite BC loss and exposes diagnostics.
+- Topology change calls `on_topology_change` and flushes teacher deques.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pytest tests/test_agent_transformer_ppo_behavior_cloning.py -v`
+
+Expected: missing `_bc` hooks / no behavior.
+
+- [ ] **Step 3: Implement minimal hooks**
+
+Modify `AgentTransformerPPO` only at the collaborator hook points listed in this plan. Avoid duplicating BC logic in the agent.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `pytest tests/test_agent_transformer_ppo_behavior_cloning.py tests/test_agent_transformer_ppo.py tests/test_agent_transformer_ppo_wrapper_integration.py -q`
+
+- [ ] **Step 5: Commit**
+
+Run: `git add algorithms/agents/agent_transformer_ppo.py tests/test_agent_transformer_ppo_behavior_cloning.py && git commit -m "feat(tppo): wire BC regularizer into TransformerPPO"`
+
+---
+
+### Task 9: BC Template, Smoke Test, and Docs
+
+**Files:**
+- Create: `configs/templates/dynamic/transformer_ppo_bc_entity_dynamic.yaml`
+- Create: `tests/test_template_transformer_ppo_bc_entity_dynamic.py`
+- Modify: `docs/transformer_ppo_spec.md`
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Write template smoke test**
+
+Mirror `tests/test_template_transformer_ppo_entity_dynamic.py` and assert the BC block resolves with `RBCCommunityPolicy`, `phaseout_mode: blend`, `ev_multiplier: 24.0`, `storage_multiplier: 0.18`.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pytest tests/test_template_transformer_ppo_bc_entity_dynamic.py -v`
+
+Expected: template file missing.
+
+- [ ] **Step 3: Add template**
+
+Copy the existing TransformerPPO dynamic entity template and add the `behavior_cloning` block. Do not modify the existing non-BC template.
+
+- [ ] **Step 4: Add docs**
+
+Append `docs/transformer_ppo_spec.md` section `13. Behavior Cloning` describing optional BC, teacher policy, phaseout, per-CA-type weights, and deferred residual policy. Add a concise note to `AGENTS.md`.
+
+- [ ] **Step 5: Verify GREEN**
+
+Run: `pytest tests/test_template_transformer_ppo_bc_entity_dynamic.py -q`
+
+- [ ] **Step 6: Commit**
+
+Run: `git add configs/templates/dynamic/transformer_ppo_bc_entity_dynamic.yaml tests/test_template_transformer_ppo_bc_entity_dynamic.py docs/transformer_ppo_spec.md AGENTS.md && git commit -m "feat(tppo): add BC entity-dynamic template and docs"`
+
+---
+
+### Task 10: Final Regression and Review
+
+**Files:**
+- All touched files.
+
+- [ ] **Step 1: Run targeted regression**
+
+Run: `pytest tests/test_ppo_components.py tests/test_warm_start_policy.py tests/test_behavior_cloning_regularizer.py tests/test_agent_transformer_ppo.py tests/test_agent_transformer_ppo_wrapper_integration.py tests/test_agent_transformer_ppo_behavior_cloning.py tests/test_template_transformer_ppo_bc_entity_dynamic.py -q`
+
+- [ ] **Step 2: Run full suite**
+
+Run: `pytest -q`
+
+- [ ] **Step 3: Inspect status and diff**
+
+Run: `git status --short && git diff --stat && git log --oneline -10`
+
+- [ ] **Step 4: Final code review**
+
+Review for:
+- No BC-specific logic leaked into `ppo_components.py` beyond `Batch.step_indices`.
+- `AgentTransformerPPO` only delegates to the collaborator.
+- No duplicated warm-start-policy registry.
+- Existing non-BC TransformerPPO behavior remains unchanged when config block absent.
+
+- [ ] **Step 5: Report results**
+
+Summarize commits, tests, and any remaining risks.

--- a/docs/transformer_ppo_spec.md
+++ b/docs/transformer_ppo_spec.md
@@ -1467,9 +1467,71 @@ Validation is performed in a single authoritative place
 
 ---
 
-## 13. Export & Checkpoint Contract (dynamic topology)
+## 13. Behavior Cloning
 
-### 13.1 ONNX export
+`AgentTransformerPPO` can optionally add a behavior-cloning (BC)
+regularizer and warm-start controller through the pipeline stage's
+`behavior_cloning` block. When enabled, the agent still learns with PPO,
+but each rollout step also records teacher actions from a configured RBC
+teacher and adds a weighted mean-squared action loss during PPO updates.
+The teacher path uses raw entity-adapter observations through
+`set_observation_context(...)`, while the Transformer policy continues to
+consume encoded observations.
+
+The shipped BC template uses `RBCCommunityPolicy` as the teacher because it
+shares the operational community-aware dispatch rules used by the baseline
+controllers. The template enables deterministic teacher actions with no
+noise and a `blend` warm-start phaseout. During phaseout, stochastic PPO
+actions are blended with teacher actions according to the remaining
+phaseout probability; deterministic evaluation is not teacher-replaced.
+
+BC weighting is configured independently from PPO hyperparameters:
+
+```yaml
+behavior_cloning:
+  enabled: true
+  weight: 0.42
+  min_weight: 0.24
+  decay_start_step: 512
+  decay_steps: 3584
+  ev_multiplier: 24.0
+  storage_multiplier: 0.18
+  warm_start:
+    policy: RBCCommunityPolicy
+    deterministic: true
+    noise_scale: 0.0
+    phaseout_steps: 6144
+    phaseout_mode: blend
+    hyperparameters: {}
+```
+
+`weight` decays linearly toward `min_weight` after `decay_start_step` for
+`decay_steps`. `ev_multiplier` and `storage_multiplier` scale BC error per
+CA type before the weighted loss is added, so EV charger imitation can be
+made more important than stationary storage imitation without changing the
+policy output contract.
+
+On topology changes, the wrapper rebuilds the entity layout and reattaches
+the agent. BC rebuilds the `RBCCommunityPolicy` teacher against the new
+observation/action names and clears teacher-action buffers for changed
+buildings so rollout steps and teacher rows stay aligned. For building-count
+changes, the full BC buffer set is recreated to match the new per-building
+layout. BC diagnostics are exposed through `get_diagnostic_metrics()` and
+`consume_latest_training_metrics()` with keys such as
+`behavior_cloning_effective_weight`, `behavior_cloning_loss`,
+`behavior_cloning_valid_samples`, `behavior_cloning_phaseout_probability`,
+and `behavior_cloning_phaseout_used`.
+
+The deferred residual policy support is intentionally not implemented in this
+version. A future residual policy can be added as a separate teacher or
+action-correction module after the BC template and topology-safe buffer
+alignment have proven stable.
+
+---
+
+## 14. Export & Checkpoint Contract (dynamic topology)
+
+### 14.1 ONNX export
 
 Per-building, per call to `export_artifacts(output_dir, context=...)`. For
 each building `b`:
@@ -1490,7 +1552,7 @@ each building `b`:
   valid if encoded length changes inside the same topology, which it
   doesn’t today but is cheap to guard against).
 
-### 13.2 Manifest entries
+### 14.2 Manifest entries
 
 `export_artifacts` MUST return the canonical artifact payload required
 by `utils/artifact_manifest.py` and validated by
@@ -1571,7 +1633,7 @@ used by debugging and tooling and are passed through verbatim by
 We export **only the topology version current at export time**; no
 cross-topology weight portability is required for production.
 
-### 13.3 Checkpoints
+### 14.3 Checkpoints
 
 - File: `<output_dir>/checkpoints/transformer_ppo_step<step>.pt`.
 - Payload (`torch.save`):
@@ -1607,11 +1669,11 @@ Run on `citylearn_three_phase_dynamic_assets_only_demo` for a small horizon.
 | `test_actions_in_valid_range` | All actions in `[-1, 1]`, no NaN |
 | `test_topology_changes_observed_during_run` | At least one `topology_version` increment in 200 steps (the assets-only demo guarantees this) |
 | `test_kpi_files_generated` | `runs/jobs/<id>/results/{result,summary}.json` exist |
-| `test_artifact_manifest_includes_onnx_per_building` | `artifact_manifest.json` lists per-building ONNX with the naming from §13.2 |
+| `test_artifact_manifest_includes_onnx_per_building` | `artifact_manifest.json` lists per-building ONNX with the naming from §14.2 |
 | `test_buffer_flush_on_topology_change_does_not_crash` | The PPO update triggered by topology change runs and the agent continues training |
 
 ---
-## 14. Decisions Log
+## 15. Decisions Log
 
 | # | Question | Decision |
 |---|---|---|

--- a/tests/test_agent_transformer_ppo_behavior_cloning.py
+++ b/tests/test_agent_transformer_ppo_behavior_cloning.py
@@ -1,0 +1,245 @@
+"""Behavior-cloning integration tests for AgentTransformerPPO."""
+from __future__ import annotations
+
+from typing import List
+
+import numpy as np
+import pytest
+
+from algorithms.agents.agent_transformer_ppo import AgentTransformerPPO
+from algorithms.agents.baseline_policies import RBCCommunityPolicy
+from tests.test_agent_transformer_ppo import (
+    _DEFAULT_ACTIONS,
+    _base_config,
+)
+from tests._entity_sample_obs_names import (
+    load_sample_observation_names_for_first_building,
+)
+
+
+class _DummySpace:
+    def __init__(self, size: int) -> None:
+        self.low = np.full(size, -1.0, dtype=np.float64)
+        self.high = np.full(size, 1.0, dtype=np.float64)
+
+
+def _bc_config(
+    *,
+    phaseout_mode: str = "probability",
+    phaseout_steps: int = 0,
+    weight: float = 0.4,
+) -> dict:
+    cfg = _base_config()
+    cfg["algorithm"]["behavior_cloning"] = {
+        "enabled": True,
+        "weight": weight,
+        "min_weight": 0.1,
+        "decay_start_step": 0,
+        "decay_steps": 100,
+        "ev_multiplier": 2.0,
+        "storage_multiplier": 1.0,
+        "warm_start": {
+            "policy": "RBCCommunityPolicy",
+            "deterministic": True,
+            "noise_scale": 0.0,
+            "phaseout_steps": phaseout_steps,
+            "phaseout_mode": phaseout_mode,
+            "hyperparameters": {},
+        },
+    }
+    return cfg
+
+
+def _make_agent(
+    *,
+    config: dict | None = None,
+    n_buildings: int = 1,
+) -> tuple[AgentTransformerPPO, List[List[str]], List[List[str]], int]:
+    obs_names = load_sample_observation_names_for_first_building()
+    obs_names_per = [list(obs_names) for _ in range(n_buildings)]
+    act_names_per = [list(_DEFAULT_ACTIONS) for _ in range(n_buildings)]
+    agent = AgentTransformerPPO(config or _base_config())
+    action_space = [_DummySpace(len(actions)) for actions in act_names_per]
+    agent.attach_environment(
+        observation_names=obs_names_per,
+        action_names=act_names_per,
+        action_space=action_space,
+        observation_space=[None] * n_buildings,
+        metadata={
+            "building_names": [f"Building_{b+1}" for b in range(n_buildings)],
+            "seconds_per_time_step": 3600,
+        },
+    )
+    obs_dim = max(
+        max(seg.feature_indices) for seg in agent._per_building[0].layout.segments
+    ) + 1
+    return agent, obs_names_per, act_names_per, obs_dim
+
+
+def _random_transition(agent: AgentTransformerPPO, obs_dim: int, rng: np.random.Generator):
+    obs = [rng.standard_normal(obs_dim).astype(np.float64)]
+    next_obs = [rng.standard_normal(obs_dim).astype(np.float64)]
+    actions = [rng.uniform(-0.5, 0.5, size=(agent._per_building[0].layout.n_ca,))]
+    return obs, actions, next_obs
+
+
+def _set_fake_teacher(agent: AgentTransformerPPO, actions: List[List[float]]) -> None:
+    assert agent._bc is not None
+
+    def compute_teacher_actions(raw_or_encoded):
+        agent._bc.set_latest_teacher_actions(actions)
+        return [list(row) for row in actions]
+
+    agent._bc.compute_teacher_actions = compute_teacher_actions
+
+
+def test_bc_absent_leaves_agent_without_regularizer() -> None:
+    agent, _, _, obs_dim = _make_agent(config=_base_config())
+
+    assert agent._bc is None
+
+    obs = [np.zeros(obs_dim, dtype=np.float64)]
+    agent.set_observation_context(raw_observations=obs, encoded_observations=obs)
+    actions = agent.predict(obs, deterministic=True)
+
+    assert len(actions) == 1
+    assert len(actions[0]) == agent._per_building[0].layout.n_ca
+
+
+def test_bc_present_attaches_teacher_policy() -> None:
+    agent, _, _, _ = _make_agent(config=_bc_config())
+
+    assert agent._bc is not None
+    assert isinstance(agent._bc.teacher_policy, RBCCommunityPolicy)
+
+
+def test_predict_computes_teacher_actions_and_blends_phaseout() -> None:
+    agent, _, _, obs_dim = _make_agent(
+        config=_bc_config(phaseout_mode="blend", phaseout_steps=4)
+    )
+    teacher_actions = [[0.25 for _ in range(agent._per_building[0].layout.n_ca)]]
+    _set_fake_teacher(agent, teacher_actions)
+    raw_obs = [np.ones(obs_dim, dtype=np.float64)]
+    encoded_obs = [np.zeros(obs_dim, dtype=np.float64)]
+
+    agent.set_observation_context(
+        raw_observations=raw_obs,
+        encoded_observations=encoded_obs,
+    )
+    actions = agent.predict(encoded_obs, deterministic=False)
+
+    assert agent._bc is not None
+    assert agent._bc.latest_teacher_actions == teacher_actions
+    metrics = agent._bc.snapshot_metrics()
+    assert metrics["behavior_cloning_phaseout_probability"] > 0.0
+    assert metrics["behavior_cloning_phaseout_used"] == pytest.approx(1.0)
+    assert actions != teacher_actions
+
+
+def test_update_records_teacher_actions_aligned_with_buffer() -> None:
+    agent, _, _, obs_dim = _make_agent(config=_bc_config())
+    teacher_actions = [[0.1 for _ in range(agent._per_building[0].layout.n_ca)]]
+    _set_fake_teacher(agent, teacher_actions)
+    rng = np.random.default_rng(1)
+
+    for step in range(3):
+        obs, actions, next_obs = _random_transition(agent, obs_dim, rng)
+        agent.set_observation_context(raw_observations=obs, encoded_observations=obs)
+        agent.predict(obs, deterministic=bool(step % 2))
+        agent.update(
+            observations=obs,
+            actions=actions,
+            rewards=[0.1],
+            next_observations=next_obs,
+            terminated=False,
+            truncated=False,
+            update_target_step=False,
+            global_learning_step=step,
+            update_step=False,
+            initial_exploration_done=True,
+        )
+
+    assert agent._bc is not None
+    for b, state in enumerate(agent._per_building):
+        assert len(agent._bc.teacher_action_buffers[b]) == len(state.buffer)
+
+
+def test_ppo_update_records_bc_metrics_when_teacher_available() -> None:
+    agent, _, _, obs_dim = _make_agent(config=_bc_config(weight=0.6))
+    teacher_actions = [[0.0 for _ in range(agent._per_building[0].layout.n_ca)]]
+    _set_fake_teacher(agent, teacher_actions)
+    rng = np.random.default_rng(2)
+
+    for step in range(agent._minibatch_size):
+        obs, actions, next_obs = _random_transition(agent, obs_dim, rng)
+        agent.set_observation_context(raw_observations=obs, encoded_observations=obs)
+        agent.predict(obs, deterministic=False)
+        agent.update(
+            observations=obs,
+            actions=actions,
+            rewards=[0.1],
+            next_observations=next_obs,
+            terminated=False,
+            truncated=False,
+            update_target_step=False,
+            global_learning_step=10,
+            update_step=step == agent._minibatch_size - 1,
+            initial_exploration_done=True,
+        )
+
+    metrics = agent.consume_latest_training_metrics()
+    assert metrics["behavior_cloning_effective_weight"] > 0.0
+    assert np.isfinite(metrics["behavior_cloning_effective_weight"])
+    assert metrics["behavior_cloning_valid_samples"] >= 0.0
+
+
+def test_topology_change_flushes_bc_buffers() -> None:
+    agent, obs_per, act_per, obs_dim = _make_agent(config=_bc_config())
+    assert agent._bc is not None
+    old_teacher = agent._bc.teacher_policy
+    teacher_actions = [[0.2 for _ in range(agent._per_building[0].layout.n_ca)]]
+    _set_fake_teacher(agent, teacher_actions)
+    rng = np.random.default_rng(3)
+
+    obs, actions, next_obs = _random_transition(agent, obs_dim, rng)
+    agent.set_observation_context(raw_observations=obs, encoded_observations=obs)
+    agent.predict(obs, deterministic=False)
+    agent.update(
+        observations=obs,
+        actions=actions,
+        rewards=[0.1],
+        next_observations=next_obs,
+        terminated=False,
+        truncated=False,
+        update_target_step=False,
+        global_learning_step=0,
+        update_step=False,
+        initial_exploration_done=True,
+    )
+    assert len(agent._bc.teacher_action_buffers[0]) == 1
+
+    orig_id = next(
+        n.split("::")[1]
+        for n in obs_per[0]
+        if n.startswith("charger::") and "::connected_ev::" not in n and "::incoming_ev::" not in n
+    )
+    new_id = "Building_1/charger_BC_NEW"
+    new_obs = list(obs_per[0])
+    new_obs.extend(
+        n.replace(f"charger::{orig_id}::", f"charger::{new_id}::", 1)
+        for n in obs_per[0]
+        if n.startswith(f"charger::{orig_id}::")
+    )
+    new_acts = list(act_per[0]) + ["electric_vehicle_storage"]
+
+    agent.attach_environment(
+        observation_names=[new_obs],
+        action_names=[new_acts],
+        action_space=[_DummySpace(len(new_acts))],
+        observation_space=[None],
+        metadata={"building_names": ["Building_1"]},
+    )
+
+    assert agent._bc.teacher_action_buffers == [[]]
+    assert agent._bc.teacher_policy is not old_teacher
+    assert isinstance(agent._bc.teacher_policy, RBCCommunityPolicy)

--- a/tests/test_agent_transformer_ppo_behavior_cloning.py
+++ b/tests/test_agent_transformer_ppo_behavior_cloning.py
@@ -126,6 +126,18 @@ def test_bc_absent_leaves_agent_without_regularizer() -> None:
     assert len(actions[0]) == agent._per_building[0].layout.n_ca
 
 
+def test_bc_absent_does_not_require_raw_observation_context() -> None:
+    agent = AgentTransformerPPO(_base_config())
+
+    assert getattr(agent, "requires_raw_observation_context", False) is False
+
+
+def test_bc_present_requires_raw_observation_context() -> None:
+    agent = AgentTransformerPPO(_bc_config())
+
+    assert agent.requires_raw_observation_context is True
+
+
 def test_bc_present_attaches_teacher_policy() -> None:
     agent, _, _, _ = _make_agent(config=_bc_config())
 

--- a/tests/test_agent_transformer_ppo_behavior_cloning.py
+++ b/tests/test_agent_transformer_ppo_behavior_cloning.py
@@ -83,6 +83,26 @@ def _random_transition(agent: AgentTransformerPPO, obs_dim: int, rng: np.random.
     return obs, actions, next_obs
 
 
+def _random_transition_for_all_buildings(
+    agent: AgentTransformerPPO,
+    obs_dim: int,
+    rng: np.random.Generator,
+):
+    obs = [
+        rng.standard_normal(obs_dim).astype(np.float64)
+        for _ in agent._per_building
+    ]
+    next_obs = [
+        rng.standard_normal(obs_dim).astype(np.float64)
+        for _ in agent._per_building
+    ]
+    actions = [
+        rng.uniform(-0.5, 0.5, size=(state.layout.n_ca,))
+        for state in agent._per_building
+    ]
+    return obs, actions, next_obs
+
+
 def _set_fake_teacher(agent: AgentTransformerPPO, actions: List[List[float]]) -> None:
     assert agent._bc is not None
 
@@ -243,3 +263,59 @@ def test_topology_change_flushes_bc_buffers() -> None:
     assert agent._bc.teacher_action_buffers == [[]]
     assert agent._bc.teacher_policy is not old_teacher
     assert isinstance(agent._bc.teacher_policy, RBCCommunityPolicy)
+
+
+def test_partial_topology_change_preserves_unchanged_bc_buffer_alignment() -> None:
+    agent, obs_per, act_per, obs_dim = _make_agent(config=_bc_config(), n_buildings=2)
+    assert agent._bc is not None
+    teacher_actions = [
+        [0.1 for _ in range(state.layout.n_ca)]
+        for state in agent._per_building
+    ]
+    _set_fake_teacher(agent, teacher_actions)
+    rng = np.random.default_rng(4)
+
+    for step in range(2):
+        obs, actions, next_obs = _random_transition_for_all_buildings(agent, obs_dim, rng)
+        agent.set_observation_context(raw_observations=obs, encoded_observations=obs)
+        agent.predict(obs, deterministic=bool(step % 2))
+        agent.update(
+            observations=obs,
+            actions=actions,
+            rewards=[0.1, 0.2],
+            next_observations=next_obs,
+            terminated=False,
+            truncated=False,
+            update_target_step=False,
+            global_learning_step=step,
+            update_step=False,
+            initial_exploration_done=True,
+        )
+
+    assert [len(state.buffer) for state in agent._per_building] == [2, 2]
+    assert [len(buffer) for buffer in agent._bc.teacher_action_buffers] == [2, 2]
+
+    orig_id = next(
+        n.split("::")[1]
+        for n in obs_per[0]
+        if n.startswith("charger::") and "::connected_ev::" not in n and "::incoming_ev::" not in n
+    )
+    new_id = "Building_1/charger_PARTIAL_BC_NEW"
+    new_obs_0 = list(obs_per[0])
+    new_obs_0.extend(
+        n.replace(f"charger::{orig_id}::", f"charger::{new_id}::", 1)
+        for n in obs_per[0]
+        if n.startswith(f"charger::{orig_id}::")
+    )
+    new_acts_0 = list(act_per[0]) + ["electric_vehicle_storage"]
+
+    agent.attach_environment(
+        observation_names=[new_obs_0, list(obs_per[1])],
+        action_names=[new_acts_0, list(act_per[1])],
+        action_space=[_DummySpace(len(new_acts_0)), _DummySpace(len(act_per[1]))],
+        observation_space=[None, None],
+        metadata={"building_names": ["Building_1", "Building_2"]},
+    )
+
+    assert [len(state.buffer) for state in agent._per_building] == [0, 2]
+    assert [len(buffer) for buffer in agent._bc.teacher_action_buffers] == [0, 2]

--- a/tests/test_behavior_cloning_regularizer.py
+++ b/tests/test_behavior_cloning_regularizer.py
@@ -233,32 +233,32 @@ def test_bc_loss_ignores_missing_teacher_and_mismatched_lengths():
     assert regularizer.snapshot_metrics()["behavior_cloning_valid_samples"] == pytest.approx(2.0)
 
 
-def test_bc_loss_applies_ca_type_multipliers_and_effective_weight():
+def test_bc_loss_normalizes_by_active_ca_type_weights():
     regularizer = _regularizer(
-        weight=0.4,
-        min_weight=0.2,
-        decay_start_step=10,
-        decay_steps=10,
-        ev_multiplier=2.0,
-        storage_multiplier=0.5,
+        weight=1.0,
+        min_weight=1.0,
+        decay_start_step=0,
+        decay_steps=0,
+        ev_multiplier=10.0,
+        storage_multiplier=1.0,
     )
     regularizer.teacher_action_buffers = [[[0.0, 0.0]]]
-    predictions = torch.tensor([[[1.0], [1.0]]])
+    predictions = torch.tensor([[[1.0], [0.0]]])
 
     loss = regularizer.bc_loss_term(
         building_idx=0,
         layout=_layout("charger", "storage"),
         predicted_means=predictions,
         step_indices=torch.tensor([0]),
-        global_learning_step=15,
+        global_learning_step=0,
     )
 
-    raw_loss = (2.0 + 0.5) / 2.0
-    assert loss.item() == pytest.approx(raw_loss * 0.3)
+    raw_loss = 10.0 / 11.0
+    assert loss.item() == pytest.approx(raw_loss)
     metrics = regularizer.snapshot_metrics()
     assert metrics["behavior_cloning_loss"] == pytest.approx(raw_loss)
-    assert metrics["behavior_cloning_weighted_loss"] == pytest.approx(raw_loss * 0.3)
-    assert metrics["behavior_cloning_effective_weight"] == pytest.approx(0.3)
+    assert metrics["behavior_cloning_weighted_loss"] == pytest.approx(raw_loss)
+    assert metrics["behavior_cloning_effective_weight"] == pytest.approx(1.0)
     assert metrics["behavior_cloning_valid_samples"] == pytest.approx(1.0)
 
 

--- a/tests/test_behavior_cloning_regularizer.py
+++ b/tests/test_behavior_cloning_regularizer.py
@@ -334,6 +334,27 @@ def test_maybe_phaseout_probability_mode_can_return_teacher_actions(monkeypatch)
     assert metrics["behavior_cloning_phaseout_used"] == pytest.approx(1.0)
 
 
+def test_maybe_phaseout_probability_mode_keeps_actor_on_teacher_shape_mismatch(monkeypatch):
+    regularizer = _regularizer(warm_start={
+        "policy": "RBCCommunityPolicy",
+        "deterministic": True,
+        "noise_scale": 0.0,
+        "phaseout_steps": 4,
+        "phaseout_mode": "probability",
+        "hyperparameters": {},
+    })
+    regularizer.set_latest_teacher_actions([[0.7], [0.9]])
+    actor_actions = [[-0.7], [-0.1, 0.1]]
+    monkeypatch.setattr(random, "random", lambda: 0.1)
+
+    actions = regularizer.maybe_phaseout(actor_actions, deterministic=False)
+
+    assert actions == [[0.7], [-0.1, 0.1]]
+    metrics = regularizer.snapshot_metrics()
+    assert metrics["behavior_cloning_phaseout_probability"] == pytest.approx(0.75)
+    assert metrics["behavior_cloning_phaseout_used"] == pytest.approx(1.0)
+
+
 def test_maybe_phaseout_deterministic_returns_actor_actions_unchanged():
     regularizer = _regularizer(warm_start={
         "policy": "RBCCommunityPolicy",

--- a/tests/test_behavior_cloning_regularizer.py
+++ b/tests/test_behavior_cloning_regularizer.py
@@ -1,7 +1,12 @@
+import random
+
+import numpy as np
 import pytest
+import torch
 
 from algorithms.agents.baseline_policies import RBCCommunityPolicy
 from algorithms.utils.behavior_cloning import BehaviorCloningRegularizer
+from algorithms.utils.entity_token_layout import BuildingTokenLayout, TokenSegment
 
 
 class DummySpace:
@@ -37,6 +42,45 @@ def _algorithm_config(**behavior_cloning_overrides):
     }
     behavior_cloning.update(behavior_cloning_overrides)
     return {"name": "AgentTransformerPPO", "behavior_cloning": behavior_cloning}
+
+
+def _regularizer(**behavior_cloning_overrides):
+    regularizer = BehaviorCloningRegularizer.from_config(
+        _algorithm_config(**behavior_cloning_overrides), _agent_config_template()
+    )
+    assert regularizer is not None
+    return regularizer
+
+
+def _layout(*ca_types):
+    segments = tuple(
+        TokenSegment(
+            family="ca",
+            type_name=type_name,
+            instance_id=f"ca_{idx}",
+            feature_indices=(idx,),
+            feature_names=(f"feature_{idx}",),
+        )
+        for idx, type_name in enumerate(ca_types)
+    )
+    return BuildingTokenLayout(
+        building_id="Building_1",
+        segments=segments,
+        n_sro=0,
+        n_ca=len(segments),
+        ca_action_names=tuple(f"action_{idx}" for idx in range(len(segments))),
+        excluded_feature_names=(),
+    )
+
+
+class FakeTeacher:
+    def __init__(self, actions):
+        self.actions = actions
+        self.calls = []
+
+    def predict(self, observations, deterministic=None):
+        self.calls.append((observations, deterministic))
+        return [[float(value) for value in action] for action in self.actions]
 
 
 def _attach_args(building_count=2):
@@ -115,6 +159,197 @@ def test_from_config_parses_enabled_config_values():
 
     regularizer.agent_config_template["algorithm"]["name"] = "mutated"
     assert agent_config_template["algorithm"]["name"] == "AgentTransformerPPO"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "step", "expected"),
+    [
+        ({"weight": 0.0}, 0, 0.0),
+        ({"weight": -0.1}, 0, 0.0),
+        ({"weight": 0.4, "decay_start_step": 100, "decay_steps": 50}, 99, 0.4),
+        ({"weight": 0.4, "min_weight": 0.05, "decay_start_step": 100, "decay_steps": 0}, 200, 0.4),
+        ({"weight": 0.4, "min_weight": 0.05, "decay_start_step": 100, "decay_steps": 100}, 150, 0.225),
+        ({"weight": 0.4, "min_weight": 0.05, "decay_start_step": 100, "decay_steps": 100}, 250, 0.05),
+        ({"weight": 0.4, "min_weight": 0.8, "decay_start_step": 100, "decay_steps": 100}, 150, 0.4),
+    ],
+)
+def test_effective_weight_schedule_cases(overrides, step, expected):
+    regularizer = _regularizer(**overrides)
+
+    assert regularizer.effective_weight(step) == pytest.approx(expected)
+
+
+def test_ca_type_weights_aligns_with_ca_layout_order():
+    regularizer = _regularizer(ev_multiplier=3.0, storage_multiplier=0.25)
+    layout = _layout("storage", "charger", "district")
+
+    weights = regularizer.ca_type_weights(
+        layout,
+        dtype=torch.float64,
+        device=torch.device("cpu"),
+    )
+
+    assert weights.dtype == torch.float64
+    assert weights.tolist() == pytest.approx([0.25, 3.0, 1.0])
+
+
+def test_bc_loss_zero_when_predicted_means_equal_teacher():
+    regularizer = _regularizer()
+    regularizer.teacher_action_buffers = [[[0.1, -0.2], [0.3, 0.4]]]
+    predictions = torch.tensor([[[0.1], [-0.2]], [[0.3], [0.4]]])
+
+    loss = regularizer.bc_loss_term(
+        building_idx=0,
+        layout=_layout("charger", "storage"),
+        predicted_means=predictions,
+        step_indices=torch.tensor([0, 1]),
+        global_learning_step=100,
+    )
+
+    assert loss.item() == pytest.approx(0.0)
+    metrics = regularizer.snapshot_metrics()
+    assert metrics["behavior_cloning_loss"] == pytest.approx(0.0)
+    assert metrics["behavior_cloning_weighted_loss"] == pytest.approx(0.0)
+    assert metrics["behavior_cloning_effective_weight"] == pytest.approx(0.4)
+    assert metrics["behavior_cloning_valid_samples"] == pytest.approx(2.0)
+
+
+def test_bc_loss_ignores_missing_teacher_and_mismatched_lengths():
+    regularizer = _regularizer()
+    regularizer.teacher_action_buffers = [[[0.0, 0.0], None, [0.5], [0.2, -0.2]]]
+    predictions = torch.tensor(
+        [[[0.0], [0.0]], [[0.9], [0.9]], [[0.9], [0.9]], [[0.2], [-0.2]]]
+    )
+
+    loss = regularizer.bc_loss_term(
+        building_idx=0,
+        layout=_layout("charger", "storage"),
+        predicted_means=predictions,
+        step_indices=torch.tensor([0, 1, 2, 3]),
+        global_learning_step=100,
+    )
+
+    assert loss.item() == pytest.approx(0.0)
+    assert regularizer.snapshot_metrics()["behavior_cloning_valid_samples"] == pytest.approx(2.0)
+
+
+def test_bc_loss_applies_ca_type_multipliers_and_effective_weight():
+    regularizer = _regularizer(
+        weight=0.4,
+        min_weight=0.2,
+        decay_start_step=10,
+        decay_steps=10,
+        ev_multiplier=2.0,
+        storage_multiplier=0.5,
+    )
+    regularizer.teacher_action_buffers = [[[0.0, 0.0]]]
+    predictions = torch.tensor([[[1.0], [1.0]]])
+
+    loss = regularizer.bc_loss_term(
+        building_idx=0,
+        layout=_layout("charger", "storage"),
+        predicted_means=predictions,
+        step_indices=torch.tensor([0]),
+        global_learning_step=15,
+    )
+
+    raw_loss = (2.0 + 0.5) / 2.0
+    assert loss.item() == pytest.approx(raw_loss * 0.3)
+    metrics = regularizer.snapshot_metrics()
+    assert metrics["behavior_cloning_loss"] == pytest.approx(raw_loss)
+    assert metrics["behavior_cloning_weighted_loss"] == pytest.approx(raw_loss * 0.3)
+    assert metrics["behavior_cloning_effective_weight"] == pytest.approx(0.3)
+    assert metrics["behavior_cloning_valid_samples"] == pytest.approx(1.0)
+
+
+def test_compute_teacher_actions_populates_latest_teacher_actions_with_fake_teacher():
+    regularizer = _regularizer(warm_start={
+        "policy": "RBCCommunityPolicy",
+        "deterministic": False,
+        "noise_scale": 0.0,
+        "phaseout_steps": 25,
+        "phaseout_mode": "probability",
+        "hyperparameters": {},
+    })
+    teacher = FakeTeacher([[0.1, -0.2], [0.3]])
+    regularizer.teacher_policy = teacher
+    observations = [np.array([1.0, 2.0]), np.array([3.0])]
+
+    actions = regularizer.compute_teacher_actions(observations)
+
+    assert actions == [[0.1, -0.2], [0.3]]
+    assert regularizer.latest_teacher_actions == [[0.1, -0.2], [0.3]]
+    assert teacher.calls == [(observations, False)]
+    actions[0][0] = 99.0
+    assert regularizer.latest_teacher_actions == [[0.1, -0.2], [0.3]]
+
+
+def test_compute_teacher_actions_without_teacher_clears_latest_actions():
+    regularizer = _regularizer()
+    regularizer.set_latest_teacher_actions([[0.1]])
+
+    assert regularizer.compute_teacher_actions([np.array([1.0])]) is None
+    assert regularizer.latest_teacher_actions is None
+
+
+def test_maybe_phaseout_blend_interpolates_and_eventually_reaches_zero_probability():
+    regularizer = _regularizer(warm_start={
+        "policy": "RBCCommunityPolicy",
+        "deterministic": True,
+        "noise_scale": 0.0,
+        "phaseout_steps": 2,
+        "phaseout_mode": "blend",
+        "hyperparameters": {},
+    })
+    regularizer.set_latest_teacher_actions([[1.0, -1.0]])
+    actor_actions = [[-1.0, 1.0]]
+
+    blended = regularizer.maybe_phaseout(actor_actions, deterministic=False)
+    final_actions = regularizer.maybe_phaseout(actor_actions, deterministic=False)
+
+    assert blended[0] == pytest.approx([0.0, 0.0])
+    assert final_actions == actor_actions
+    metrics = regularizer.snapshot_metrics()
+    assert metrics["behavior_cloning_phaseout_probability"] == pytest.approx(0.0)
+    assert metrics["behavior_cloning_phaseout_used"] == pytest.approx(0.0)
+
+
+def test_maybe_phaseout_probability_mode_can_return_teacher_actions(monkeypatch):
+    regularizer = _regularizer(warm_start={
+        "policy": "RBCCommunityPolicy",
+        "deterministic": True,
+        "noise_scale": 0.0,
+        "phaseout_steps": 4,
+        "phaseout_mode": "probability",
+        "hyperparameters": {},
+    })
+    regularizer.set_latest_teacher_actions([[0.7]])
+    monkeypatch.setattr(random, "random", lambda: 0.1)
+
+    actions = regularizer.maybe_phaseout([[-0.7]], deterministic=False)
+
+    assert actions == [[0.7]]
+    metrics = regularizer.snapshot_metrics()
+    assert metrics["behavior_cloning_phaseout_probability"] == pytest.approx(0.75)
+    assert metrics["behavior_cloning_phaseout_used"] == pytest.approx(1.0)
+
+
+def test_maybe_phaseout_deterministic_returns_actor_actions_unchanged():
+    regularizer = _regularizer(warm_start={
+        "policy": "RBCCommunityPolicy",
+        "deterministic": True,
+        "noise_scale": 0.0,
+        "phaseout_steps": 4,
+        "phaseout_mode": "blend",
+        "hyperparameters": {},
+    })
+    regularizer.set_latest_teacher_actions([[0.7]])
+    actor_actions = [[-0.7]]
+
+    assert regularizer.maybe_phaseout(actor_actions, deterministic=True) is actor_actions
+    metrics = regularizer.snapshot_metrics()
+    assert metrics["behavior_cloning_phaseout_probability"] == pytest.approx(0.0)
+    assert metrics["behavior_cloning_phaseout_used"] == pytest.approx(0.0)
 
 
 def test_attach_environment_builds_teacher_and_initializes_buffers():
@@ -226,6 +461,12 @@ def test_snapshot_metrics_reports_lifecycle_diagnostics():
         "behavior_cloning_teacher_enabled": 0.0,
         "behavior_cloning_latest_teacher_available": 0.0,
         "behavior_cloning_teacher_buffer_size": 0.0,
+        "behavior_cloning_effective_weight": 0.0,
+        "behavior_cloning_loss": 0.0,
+        "behavior_cloning_weighted_loss": 0.0,
+        "behavior_cloning_valid_samples": 0.0,
+        "behavior_cloning_phaseout_probability": 0.0,
+        "behavior_cloning_phaseout_used": 0.0,
     }
 
     regularizer.attach_environment(**_attach_args())
@@ -237,6 +478,12 @@ def test_snapshot_metrics_reports_lifecycle_diagnostics():
         "behavior_cloning_teacher_enabled": 1.0,
         "behavior_cloning_latest_teacher_available": 1.0,
         "behavior_cloning_teacher_buffer_size": 2.0,
+        "behavior_cloning_effective_weight": 0.0,
+        "behavior_cloning_loss": 0.0,
+        "behavior_cloning_weighted_loss": 0.0,
+        "behavior_cloning_valid_samples": 0.0,
+        "behavior_cloning_phaseout_probability": 0.0,
+        "behavior_cloning_phaseout_used": 0.0,
     }
 
     regularizer.set_latest_teacher_actions(None)
@@ -245,4 +492,10 @@ def test_snapshot_metrics_reports_lifecycle_diagnostics():
         "behavior_cloning_teacher_enabled": 1.0,
         "behavior_cloning_latest_teacher_available": 0.0,
         "behavior_cloning_teacher_buffer_size": 2.0,
+        "behavior_cloning_effective_weight": 0.0,
+        "behavior_cloning_loss": 0.0,
+        "behavior_cloning_weighted_loss": 0.0,
+        "behavior_cloning_valid_samples": 0.0,
+        "behavior_cloning_phaseout_probability": 0.0,
+        "behavior_cloning_phaseout_used": 0.0,
     }

--- a/tests/test_behavior_cloning_regularizer.py
+++ b/tests/test_behavior_cloning_regularizer.py
@@ -167,6 +167,23 @@ def test_record_transition_appends_none_when_teacher_missing():
     assert regularizer.teacher_action_for(1, 0) is None
 
 
+def test_set_latest_teacher_actions_none_clears_and_records_none():
+    regularizer = BehaviorCloningRegularizer.from_config(
+        _algorithm_config(), _agent_config_template()
+    )
+    regularizer.attach_environment(**_attach_args())
+    regularizer.set_latest_teacher_actions([[0.1], [0.2]])
+
+    regularizer.set_latest_teacher_actions(None)
+    regularizer.record_transition(0)
+    regularizer.record_transition(1)
+
+    assert regularizer.latest_teacher_actions is None
+    assert regularizer.teacher_action_buffers == [[None], [None]]
+    assert regularizer.teacher_action_for(0, 0) is None
+    assert regularizer.teacher_action_for(1, 0) is None
+
+
 def test_on_buffer_flushed_clears_only_one_building():
     regularizer = BehaviorCloningRegularizer.from_config(
         _algorithm_config(), _agent_config_template()
@@ -198,3 +215,34 @@ def test_on_topology_change_clears_buffers_and_reattaches_teacher():
     assert isinstance(regularizer.teacher_policy, RBCCommunityPolicy)
     assert regularizer.latest_teacher_actions is None
     assert regularizer.teacher_action_buffers == [[]]
+
+
+def test_snapshot_metrics_reports_lifecycle_diagnostics():
+    regularizer = BehaviorCloningRegularizer.from_config(
+        _algorithm_config(), _agent_config_template()
+    )
+
+    assert regularizer.snapshot_metrics() == {
+        "behavior_cloning_teacher_enabled": 0.0,
+        "behavior_cloning_latest_teacher_available": 0.0,
+        "behavior_cloning_teacher_buffer_size": 0.0,
+    }
+
+    regularizer.attach_environment(**_attach_args())
+    regularizer.set_latest_teacher_actions([[0.1], [0.2]])
+    regularizer.record_transition(0)
+    regularizer.record_transition(1)
+
+    assert regularizer.snapshot_metrics() == {
+        "behavior_cloning_teacher_enabled": 1.0,
+        "behavior_cloning_latest_teacher_available": 1.0,
+        "behavior_cloning_teacher_buffer_size": 2.0,
+    }
+
+    regularizer.set_latest_teacher_actions(None)
+
+    assert regularizer.snapshot_metrics() == {
+        "behavior_cloning_teacher_enabled": 1.0,
+        "behavior_cloning_latest_teacher_available": 0.0,
+        "behavior_cloning_teacher_buffer_size": 2.0,
+    }

--- a/tests/test_behavior_cloning_regularizer.py
+++ b/tests/test_behavior_cloning_regularizer.py
@@ -473,6 +473,24 @@ def test_on_topology_change_clears_buffers_and_reattaches_teacher():
     assert regularizer.teacher_action_buffers == [[]]
 
 
+def test_on_topology_change_preserves_unchanged_building_buffers():
+    regularizer = BehaviorCloningRegularizer.from_config(
+        _algorithm_config(), _agent_config_template()
+    )
+    regularizer.attach_environment(**_attach_args())
+    old_teacher = regularizer.teacher_policy
+    regularizer.set_latest_teacher_actions([[0.1], [0.2]])
+    regularizer.record_transition(0)
+    regularizer.record_transition(1)
+
+    regularizer.on_topology_change(**_attach_args(), changed_buildings=[0])
+
+    assert regularizer.teacher_policy is not old_teacher
+    assert isinstance(regularizer.teacher_policy, RBCCommunityPolicy)
+    assert regularizer.latest_teacher_actions is None
+    assert regularizer.teacher_action_buffers == [[], [[0.2]]]
+
+
 def test_snapshot_metrics_reports_lifecycle_diagnostics():
     regularizer = BehaviorCloningRegularizer.from_config(
         _algorithm_config(), _agent_config_template()

--- a/tests/test_behavior_cloning_regularizer.py
+++ b/tests/test_behavior_cloning_regularizer.py
@@ -1,0 +1,200 @@
+import pytest
+
+from algorithms.agents.baseline_policies import RBCCommunityPolicy
+from algorithms.utils.behavior_cloning import BehaviorCloningRegularizer
+
+
+class DummySpace:
+    def __init__(self, low, high):
+        self.low = low
+        self.high = high
+
+
+def _agent_config_template():
+    return {
+        "algorithm": {"name": "AgentTransformerPPO"},
+        "simulator": {"interface": "entity"},
+    }
+
+
+def _algorithm_config(**behavior_cloning_overrides):
+    behavior_cloning = {
+        "enabled": True,
+        "weight": 0.4,
+        "min_weight": 0.05,
+        "decay_start_step": 100,
+        "decay_steps": 500,
+        "ev_multiplier": 2.0,
+        "storage_multiplier": 0.5,
+        "warm_start": {
+            "policy": "RBCCommunityPolicy",
+            "deterministic": True,
+            "noise_scale": 0.03,
+            "phaseout_steps": 25,
+            "phaseout_mode": "linear",
+            "hyperparameters": {"pv_preferred_charge_rate": 0.37},
+        },
+    }
+    behavior_cloning.update(behavior_cloning_overrides)
+    return {"name": "AgentTransformerPPO", "behavior_cloning": behavior_cloning}
+
+
+def _attach_args(building_count=2):
+    observation_names = [
+        ["hour", "pv_power_kw", "electrical_storage_soc"],
+        ["hour", "load_power_kw"],
+    ][:building_count]
+    action_names = [
+        ["electrical_storage"],
+        ["electric_vehicle_storage_charger_2_1"],
+    ][:building_count]
+    action_space = [
+        DummySpace([-1.0], [1.0]),
+        DummySpace([0.0], [1.0]),
+    ][:building_count]
+    observation_space = [object() for _ in range(building_count)]
+    metadata = {
+        "building_names": [f"Building_{idx + 1}" for idx in range(building_count)],
+        "seconds_per_time_step": 900,
+    }
+    return {
+        "observation_names": observation_names,
+        "action_names": action_names,
+        "action_space": action_space,
+        "observation_space": observation_space,
+        "metadata": metadata,
+    }
+
+
+def test_from_config_returns_none_when_absent_disabled_or_missing_warm_start():
+    assert BehaviorCloningRegularizer.from_config({}, _agent_config_template()) is None
+    assert (
+        BehaviorCloningRegularizer.from_config(
+            _algorithm_config(enabled=False), _agent_config_template()
+        )
+        is None
+    )
+    algorithm_cfg_without_warm_start = _algorithm_config()
+    del algorithm_cfg_without_warm_start["behavior_cloning"]["warm_start"]
+    assert (
+        BehaviorCloningRegularizer.from_config(
+            algorithm_cfg_without_warm_start, _agent_config_template()
+        )
+        is None
+    )
+    assert (
+        BehaviorCloningRegularizer.from_config(
+            _algorithm_config(warm_start=None), _agent_config_template()
+        )
+        is None
+    )
+
+
+def test_from_config_parses_enabled_config_values():
+    agent_config_template = _agent_config_template()
+    regularizer = BehaviorCloningRegularizer.from_config(
+        _algorithm_config(), agent_config_template
+    )
+
+    assert regularizer is not None
+    assert regularizer.enabled is True
+    assert regularizer.weight == pytest.approx(0.4)
+    assert regularizer.min_weight == pytest.approx(0.05)
+    assert regularizer.decay_start_step == 100
+    assert regularizer.decay_steps == 500
+    assert regularizer.ev_multiplier == pytest.approx(2.0)
+    assert regularizer.storage_multiplier == pytest.approx(0.5)
+    assert regularizer.policy == "RBCCommunityPolicy"
+    assert regularizer.deterministic is True
+    assert regularizer.noise_scale == pytest.approx(0.03)
+    assert regularizer.phaseout_steps == 25
+    assert regularizer.phaseout_mode == "linear"
+    assert regularizer.hyperparameters == {"pv_preferred_charge_rate": 0.37}
+    assert regularizer.teacher_policy is None
+    assert regularizer.latest_teacher_actions is None
+
+    regularizer.agent_config_template["algorithm"]["name"] = "mutated"
+    assert agent_config_template["algorithm"]["name"] == "AgentTransformerPPO"
+
+
+def test_attach_environment_builds_teacher_and_initializes_buffers():
+    regularizer = BehaviorCloningRegularizer.from_config(
+        _algorithm_config(), _agent_config_template()
+    )
+
+    regularizer.attach_environment(**_attach_args())
+
+    assert isinstance(regularizer.teacher_policy, RBCCommunityPolicy)
+    assert regularizer.teacher_policy._action_labels == [
+        ["electrical_storage"],
+        ["electric_vehicle_storage_charger_2_1"],
+    ]
+    assert regularizer.teacher_action_buffers == [[], []]
+
+
+def test_record_transition_aligns_teacher_actions_by_building():
+    regularizer = BehaviorCloningRegularizer.from_config(
+        _algorithm_config(), _agent_config_template()
+    )
+    regularizer.attach_environment(**_attach_args())
+
+    actions = [[0.1, 0.2], [0.3]]
+    regularizer.set_latest_teacher_actions(actions)
+    actions[0][0] = 99.0
+    regularizer.record_transition(0)
+    regularizer.record_transition(1)
+
+    building_0_action = regularizer.teacher_action_for(0, 0)
+    building_1_action = regularizer.teacher_action_for(1, 0)
+    assert building_0_action == [0.1, 0.2]
+    assert building_1_action == [0.3]
+
+    building_0_action.append(99.0)
+    assert regularizer.teacher_action_for(0, 0) == [0.1, 0.2]
+
+
+def test_record_transition_appends_none_when_teacher_missing():
+    regularizer = BehaviorCloningRegularizer.from_config(
+        _algorithm_config(), _agent_config_template()
+    )
+    regularizer.attach_environment(**_attach_args())
+
+    regularizer.record_transition(0)
+    regularizer.set_latest_teacher_actions([[0.1]])
+    regularizer.record_transition(1)
+
+    assert regularizer.teacher_action_for(0, 0) is None
+    assert regularizer.teacher_action_for(1, 0) is None
+
+
+def test_on_buffer_flushed_clears_only_one_building():
+    regularizer = BehaviorCloningRegularizer.from_config(
+        _algorithm_config(), _agent_config_template()
+    )
+    regularizer.attach_environment(**_attach_args())
+    regularizer.set_latest_teacher_actions([[0.1], [0.2]])
+    regularizer.record_transition(0)
+    regularizer.record_transition(1)
+
+    regularizer.on_buffer_flushed(0)
+
+    assert regularizer.teacher_action_for(0, 0) is None
+    assert regularizer.teacher_action_for(1, 0) == [0.2]
+
+
+def test_on_topology_change_clears_buffers_and_reattaches_teacher():
+    regularizer = BehaviorCloningRegularizer.from_config(
+        _algorithm_config(), _agent_config_template()
+    )
+    regularizer.attach_environment(**_attach_args())
+    old_teacher = regularizer.teacher_policy
+    regularizer.set_latest_teacher_actions([[0.1], [0.2]])
+    regularizer.record_transition(0)
+    regularizer.record_transition(1)
+
+    regularizer.on_topology_change(**_attach_args(building_count=1))
+
+    assert regularizer.teacher_policy is not old_teacher
+    assert isinstance(regularizer.teacher_policy, RBCCommunityPolicy)
+    assert regularizer.latest_teacher_actions is None
+    assert regularizer.teacher_action_buffers == [[]]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -24,11 +24,13 @@ class RecordingUnit(ExecutionUnit):
         name: str,
         predict_output: Any = None,
         use_raw_observations: bool = False,
+        requires_raw_observation_context: bool = False,
         initial_exploration_done: bool = True,
     ) -> None:
         self.name = name
         self._predict_output = predict_output if predict_output is not None else [[0.0]]
         self.use_raw_observations = use_raw_observations
+        self.requires_raw_observation_context = requires_raw_observation_context
         self._initial_exploration_done = initial_exploration_done
 
         self.predict_calls: List[Dict[str, Any]] = []
@@ -233,6 +235,17 @@ class TestPipelineLifecycle:
         assert Pipeline([raw, raw]).use_raw_observations is True
         assert Pipeline([none_raw, raw]).use_raw_observations is False
         assert Pipeline([none_raw, raw]).requires_raw_observation_context is True
+
+    def test_requires_raw_observation_context_aggregates_stage_requirement(self) -> None:
+        encoded_stage = RecordingUnit("encoded", use_raw_observations=False)
+        bc_stage = RecordingUnit(
+            "bc",
+            use_raw_observations=False,
+            requires_raw_observation_context=True,
+        )
+
+        assert Pipeline([encoded_stage]).requires_raw_observation_context is False
+        assert Pipeline([encoded_stage, bc_stage]).requires_raw_observation_context is True
 
     def test_attach_environment_routes_raw_and_encoded_names_per_stage(self) -> None:
         manager = RecordingUnit("manager", use_raw_observations=False)

--- a/tests/test_ppo_components.py
+++ b/tests/test_ppo_components.py
@@ -194,6 +194,34 @@ class TestRolloutBuffer:
         assert len(buffer.rewards) == 0
 
 
+def test_rollout_buffer_batches_include_original_step_indices():
+    import torch
+    from algorithms.utils.ppo_components import RolloutBuffer
+
+    buffer = RolloutBuffer(gamma=0.99, gae_lambda=0.95)
+    for idx in range(5):
+        buffer.add(
+            observation=torch.tensor([float(idx)]),
+            action=torch.tensor([[float(idx)]]),
+            log_prob=torch.tensor([0.0]),
+            reward=0.0,
+            value=torch.tensor([0.0]),
+            done=False,
+        )
+    buffer.compute_returns_and_advantages(torch.tensor([0.0]))
+
+    seen = []
+    for batch in buffer.get_batches(batch_size=2):
+        assert batch.step_indices.dtype == torch.long
+        assert batch.step_indices.shape[0] == batch.observations.shape[0]
+        for row, original_idx in enumerate(batch.step_indices.tolist()):
+            assert batch.observations[row, 0].item() == float(original_idx)
+            assert batch.actions[row, 0, 0].item() == float(original_idx)
+            seen.append(original_idx)
+
+    assert sorted(seen) == [0, 1, 2, 3, 4]
+
+
 class TestPPOLoss:
     """Tests for PPO loss computation."""
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -156,6 +156,7 @@ class TestStageToAgentView:
             "networks": {"actor": {"layers": [8]}},
             "replay_buffer": {"class": "MultiAgentReplayBuffer", "capacity": 10, "batch_size": 2},
             "exploration": {"strategy": "GaussianNoise", "params": {}},
+            "behavior_cloning": {"enabled": True},
         }
         view = _stage_to_agent_view({}, stage)
 
@@ -163,6 +164,7 @@ class TestStageToAgentView:
         assert algorithm_block["networks"] == {"actor": {"layers": [8]}}
         assert algorithm_block["replay_buffer"]["class"] == "MultiAgentReplayBuffer"
         assert algorithm_block["exploration"]["strategy"] == "GaussianNoise"
+        assert algorithm_block["behavior_cloning"] == {"enabled": True}
 
     def test_does_not_mutate_input_global_config(self) -> None:
         global_config = {"metadata": {"experiment_name": "exp"}}

--- a/tests/test_rl_agents_contract.py
+++ b/tests/test_rl_agents_contract.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 import yaml
 
+from algorithms.agents.baseline_policies import RBCSmartPolicy
 from algorithms.agents.maddpg_agent import MADDPG
 from algorithms.agents.matd3_agent import MATD3
 from algorithms.agents.masac_agent import MASAC
@@ -126,6 +127,25 @@ def _attach_bounds(agent) -> None:
         observation_space=[],
         metadata={"seconds_per_time_step": 3600},
     )
+
+
+def test_ppo_warm_start_policy_initializes_attached_teacher():
+    config = _base_rl_config("IPPO")
+    params = config["pipeline"][0]["exploration"]["params"]
+    params.update(
+        {
+            "initial_exploration_strategy": "policy",
+            "warm_start_policy": "RBCSmartPolicy",
+            "warm_start_policy_hyperparameters": {"pv_preferred_charge_rate": 0.37},
+        }
+    )
+    agent = IPPO(_agent_view(config))
+
+    _attach_bounds(agent)
+
+    assert isinstance(agent._warm_start_policy, RBCSmartPolicy)
+    assert agent._warm_start_policy._action_labels == agent.action_names
+    assert agent._warm_start_policy.pv_preferred_charge_rate == pytest.approx(0.37)
 
 
 def _transition(step: int):

--- a/tests/test_template_transformer_ppo_bc_entity_dynamic.py
+++ b/tests/test_template_transformer_ppo_bc_entity_dynamic.py
@@ -115,11 +115,19 @@ def test_template_passes_schema_validation_and_resolves_bc_block() -> None:
     assert "bc" in cfg["metadata"]["run_name"].lower()
     assert stage.behavior_cloning is not None
     assert stage.behavior_cloning.enabled is True
-    assert stage.behavior_cloning.warm_start is not None
-    assert stage.behavior_cloning.warm_start.policy == "RBCCommunityPolicy"
-    assert stage.behavior_cloning.warm_start.phaseout_mode == "blend"
+    assert stage.behavior_cloning.weight == pytest.approx(0.42)
+    assert stage.behavior_cloning.min_weight == pytest.approx(0.24)
+    assert stage.behavior_cloning.decay_start_step == 512
+    assert stage.behavior_cloning.decay_steps == 3584
     assert stage.behavior_cloning.ev_multiplier == pytest.approx(24.0)
     assert stage.behavior_cloning.storage_multiplier == pytest.approx(0.18)
+    assert stage.behavior_cloning.warm_start is not None
+    assert stage.behavior_cloning.warm_start.policy == "RBCCommunityPolicy"
+    assert stage.behavior_cloning.warm_start.deterministic is True
+    assert stage.behavior_cloning.warm_start.noise_scale == pytest.approx(0.0)
+    assert stage.behavior_cloning.warm_start.phaseout_steps == 6144
+    assert stage.behavior_cloning.warm_start.phaseout_mode == "blend"
+    assert stage.behavior_cloning.warm_start.hyperparameters == {}
 
 
 def test_transformer_ppo_bc_smoke_records_bc_metrics_across_topology_change() -> None:

--- a/tests/test_template_transformer_ppo_bc_entity_dynamic.py
+++ b/tests/test_template_transformer_ppo_bc_entity_dynamic.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 
 from algorithms.agents.agent_transformer_ppo import AgentTransformerPPO
+from algorithms.registry import build_execution_unit
 from tests.test_agent_transformer_ppo_wrapper_integration import (
     _DummyEntityEnvForPPO,
 )
@@ -128,6 +129,31 @@ def test_template_passes_schema_validation_and_resolves_bc_block() -> None:
     assert stage.behavior_cloning.warm_start.phaseout_steps == 6144
     assert stage.behavior_cloning.warm_start.phaseout_mode == "blend"
     assert stage.behavior_cloning.warm_start.hyperparameters == {}
+
+
+def test_bc_template_build_execution_unit_enables_regularizer() -> None:
+    cfg = _load_template()
+    cfg["pipeline"][0]["tokenizer_config_path"] = _TOKENIZER_FIXTURE
+    cfg["pipeline"][0]["transformer"] = {
+        "d_model": 16,
+        "nhead": 2,
+        "num_layers": 1,
+        "dim_feedforward": 32,
+        "dropout": 0.0,
+    }
+    cfg["pipeline"][0]["hyperparameters"].update(
+        {
+            "minibatch_size": 4,
+            "actor_hidden_dim": 32,
+            "critic_hidden_dim": 32,
+        }
+    )
+
+    agent = build_execution_unit(cfg)
+
+    assert isinstance(agent, AgentTransformerPPO)
+    assert agent._bc is not None
+    assert agent.requires_raw_observation_context is True
 
 
 def test_transformer_ppo_bc_smoke_records_bc_metrics_across_topology_change() -> None:

--- a/tests/test_template_transformer_ppo_bc_entity_dynamic.py
+++ b/tests/test_template_transformer_ppo_bc_entity_dynamic.py
@@ -1,0 +1,205 @@
+"""Template and smoke tests for Transformer-PPO behavior cloning."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import numpy as np
+import pytest
+import yaml
+
+from algorithms.agents.agent_transformer_ppo import AgentTransformerPPO
+from tests.test_agent_transformer_ppo_wrapper_integration import (
+    _DummyEntityEnvForPPO,
+)
+from tests.test_wrapper_entity_mode import _entity_config
+from utils.wrapper_citylearn import Wrapper_CityLearn
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_PATH = (
+    REPO_ROOT / "configs/templates/dynamic/transformer_ppo_bc_entity_dynamic.yaml"
+)
+DOC_PATH = REPO_ROOT / "docs/transformer_ppo_spec.md"
+AGENTS_PATH = REPO_ROOT / "AGENTS.md"
+_TOKENIZER_FIXTURE = "tests/fixtures/tokenizer_dummy_env.json"
+
+
+def _load_template() -> dict:
+    with TEMPLATE_PATH.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _bc_ppo_algo_config() -> Dict[str, Any]:
+    return {
+        "name": "AgentTransformerPPO",
+        "tokenizer_config_path": _TOKENIZER_FIXTURE,
+        "transformer": {
+            "d_model": 16,
+            "nhead": 2,
+            "num_layers": 1,
+            "dim_feedforward": 32,
+            "dropout": 0.0,
+        },
+        "hyperparameters": {
+            "learning_rate": 1.0e-3,
+            "gamma": 0.99,
+            "gae_lambda": 0.95,
+            "clip_eps": 0.2,
+            "ppo_epochs": 1,
+            "minibatch_size": 4,
+            "entropy_coeff": 0.0,
+            "value_coeff": 0.5,
+            "max_grad_norm": 0.5,
+            "actor_hidden_dim": 32,
+            "critic_hidden_dim": 32,
+        },
+        "behavior_cloning": {
+            "enabled": True,
+            "weight": 0.42,
+            "min_weight": 0.24,
+            "decay_start_step": 512,
+            "decay_steps": 3584,
+            "ev_multiplier": 24.0,
+            "storage_multiplier": 0.18,
+            "warm_start": {
+                "policy": "RBCCommunityPolicy",
+                "deterministic": True,
+                "noise_scale": 0.0,
+                "phaseout_steps": 6144,
+                "phaseout_mode": "blend",
+                "hyperparameters": {},
+            },
+        },
+    }
+
+
+def _bc_full_config() -> Dict[str, Any]:
+    return {"algorithm": _bc_ppo_algo_config(), "training": {"seed": 7}}
+
+
+def _rollout_transition(
+    wrapper: Wrapper_CityLearn,
+    agent: AgentTransformerPPO,
+    observations: List[np.ndarray],
+    *,
+    step: int,
+    update_step: bool,
+) -> None:
+    actions = wrapper.predict(observations, deterministic=False)
+    next_observations = [
+        np.asarray(obs, dtype=np.float64) + 0.01 for obs in observations
+    ]
+    agent.update(
+        observations=observations,
+        actions=[np.asarray(row, dtype=np.float64) for row in actions],
+        rewards=[0.1 for _ in observations],
+        next_observations=next_observations,
+        terminated=False,
+        truncated=False,
+        update_target_step=False,
+        global_learning_step=step,
+        update_step=update_step,
+        initial_exploration_done=True,
+    )
+
+
+def test_template_passes_schema_validation_and_resolves_bc_block() -> None:
+    from utils.config_schema import validate_config
+
+    cfg = _load_template()
+    resolved = validate_config(cfg)
+    stage = resolved.pipeline[0]
+
+    assert cfg["pipeline"][0]["algorithm"] == "AgentTransformerPPO"
+    assert "bc" in cfg["metadata"]["experiment_name"].lower()
+    assert "bc" in cfg["metadata"]["run_name"].lower()
+    assert stage.behavior_cloning is not None
+    assert stage.behavior_cloning.enabled is True
+    assert stage.behavior_cloning.warm_start is not None
+    assert stage.behavior_cloning.warm_start.policy == "RBCCommunityPolicy"
+    assert stage.behavior_cloning.warm_start.phaseout_mode == "blend"
+    assert stage.behavior_cloning.ev_multiplier == pytest.approx(24.0)
+    assert stage.behavior_cloning.storage_multiplier == pytest.approx(0.18)
+
+
+def test_transformer_ppo_bc_smoke_records_bc_metrics_across_topology_change() -> None:
+    env = _DummyEntityEnvForPPO()
+    cfg = _entity_config()
+    cfg["pipeline"] = [
+        {"algorithm": "AgentTransformerPPO", "count": 1, "hyperparameters": {}}
+    ]
+    wrapper = Wrapper_CityLearn(env=env, config=cfg, job_id="ppo-bc-entity-smoke")
+    agent = AgentTransformerPPO(_bc_full_config())
+    wrapper.set_model(agent)
+
+    observations = wrapper._apply_entity_layout(
+        env._observation_payload(version=0), force_attach=False
+    )
+    initial_topology_version = wrapper._entity_topology_version
+    initial_total_action_count = sum(
+        state.layout.n_ca for state in agent._per_building
+    )
+
+    for step in range(agent._minibatch_size):
+        _rollout_transition(
+            wrapper,
+            agent,
+            observations,
+            step=step,
+            update_step=step == agent._minibatch_size - 1,
+        )
+
+    assert agent._bc is not None
+    diagnostics = agent.get_diagnostic_metrics()
+    training_metrics = agent.consume_latest_training_metrics()
+    assert diagnostics["behavior_cloning_teacher_enabled"] == pytest.approx(1.0)
+    assert diagnostics["behavior_cloning_latest_teacher_available"] == pytest.approx(1.0)
+    assert diagnostics["behavior_cloning_phaseout_probability"] > 0.0
+    assert diagnostics["behavior_cloning_phaseout_used"] == pytest.approx(1.0)
+    assert training_metrics["behavior_cloning_effective_weight"] > 0.0
+    assert np.isfinite(training_metrics["behavior_cloning_effective_weight"])
+    assert "behavior_cloning_loss" in training_metrics
+    assert "behavior_cloning_valid_samples" in training_metrics
+    assert training_metrics["behavior_cloning_valid_samples"] > 0.0
+
+    env._version = 1
+    changed_observations = wrapper._apply_entity_layout(
+        env._observation_payload(version=1),
+        force_attach=False,
+    )
+
+    assert wrapper._entity_topology_version == initial_topology_version + 1
+    assert len(changed_observations) == 2
+    assert len(agent._per_building) == 2
+    assert sum(state.layout.n_ca for state in agent._per_building) != (
+        initial_total_action_count
+    )
+    assert [len(buffer) for buffer in agent._bc.teacher_action_buffers] == [0, 0]
+
+    _rollout_transition(
+        wrapper,
+        agent,
+        changed_observations,
+        step=agent._minibatch_size,
+        update_step=False,
+    )
+    assert [len(buffer) for buffer in agent._bc.teacher_action_buffers] == [1, 1]
+
+
+def test_docs_describe_transformer_ppo_behavior_cloning() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+
+    assert "## 13. Behavior Cloning" in text
+    assert "RBCCommunityPolicy" in text
+    assert "phaseout" in text
+    assert "ev_multiplier" in text
+    assert "storage_multiplier" in text
+    assert "deferred residual policy" in text
+
+
+def test_agents_doc_mentions_transformer_ppo_bc_support() -> None:
+    text = AGENTS_PATH.read_text(encoding="utf-8")
+
+    assert "AgentTransformerPPO" in text
+    assert "behavior cloning" in text
+    assert "warm-start" in text

--- a/tests/test_template_transformer_ppo_entity_dynamic.py
+++ b/tests/test_template_transformer_ppo_entity_dynamic.py
@@ -80,6 +80,19 @@ def test_transformer_ppo_stage_rejects_invalid_behavior_cloning_phaseout_mode() 
         validate_config(cfg)
 
 
+def test_transformer_ppo_stage_rejects_enabled_behavior_cloning_without_warm_start() -> None:
+    from utils.config_schema import validate_config
+
+    cfg = _load_template()
+    cfg["pipeline"][0]["behavior_cloning"] = {
+        "enabled": True,
+        "weight": 0.42,
+    }
+
+    with pytest.raises(ValidationError, match="warm_start"):
+        validate_config(cfg)
+
+
 def test_transformer_ppo_stage_without_behavior_cloning_defaults_to_none() -> None:
     from utils.config_schema import validate_config
 

--- a/tests/test_template_transformer_ppo_entity_dynamic.py
+++ b/tests/test_template_transformer_ppo_entity_dynamic.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import yaml
+from pydantic import ValidationError
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 TEMPLATE_PATH = REPO_ROOT / "configs/templates/dynamic/transformer_ppo_entity_dynamic.yaml"
@@ -20,6 +22,72 @@ def test_template_passes_schema_validation() -> None:
 
     cfg = _load_template()
     validate_config(cfg)  # should not raise
+
+
+def test_transformer_ppo_stage_accepts_behavior_cloning_config() -> None:
+    from utils.config_schema import validate_config
+
+    cfg = _load_template()
+    cfg["pipeline"][0]["behavior_cloning"] = {
+        "enabled": True,
+        "weight": 0.42,
+        "min_weight": 0.24,
+        "decay_start_step": 512,
+        "decay_steps": 3584,
+        "ev_multiplier": 24.0,
+        "storage_multiplier": 0.18,
+        "warm_start": {
+            "policy": "RBCCommunityPolicy",
+            "deterministic": True,
+            "noise_scale": 0.0,
+            "phaseout_steps": 6144,
+            "phaseout_mode": "blend",
+            "hyperparameters": {},
+        },
+    }
+
+    stage = validate_config(cfg).pipeline[0]
+
+    assert stage.behavior_cloning is not None
+    assert stage.behavior_cloning.enabled is True
+    assert stage.behavior_cloning.weight == pytest.approx(0.42)
+    assert stage.behavior_cloning.min_weight == pytest.approx(0.24)
+    assert stage.behavior_cloning.decay_start_step == 512
+    assert stage.behavior_cloning.decay_steps == 3584
+    assert stage.behavior_cloning.ev_multiplier == pytest.approx(24.0)
+    assert stage.behavior_cloning.storage_multiplier == pytest.approx(0.18)
+    assert stage.behavior_cloning.warm_start is not None
+    assert stage.behavior_cloning.warm_start.policy == "RBCCommunityPolicy"
+    assert stage.behavior_cloning.warm_start.deterministic is True
+    assert stage.behavior_cloning.warm_start.noise_scale == pytest.approx(0.0)
+    assert stage.behavior_cloning.warm_start.phaseout_steps == 6144
+    assert stage.behavior_cloning.warm_start.phaseout_mode == "blend"
+    assert stage.behavior_cloning.warm_start.hyperparameters == {}
+
+
+def test_transformer_ppo_stage_rejects_invalid_behavior_cloning_phaseout_mode() -> None:
+    from utils.config_schema import validate_config
+
+    cfg = _load_template()
+    cfg["pipeline"][0]["behavior_cloning"] = {
+        "warm_start": {
+            "policy": "RBCCommunityPolicy",
+            "phaseout_mode": "invalid",
+        },
+    }
+
+    with pytest.raises(ValidationError):
+        validate_config(cfg)
+
+
+def test_transformer_ppo_stage_without_behavior_cloning_defaults_to_none() -> None:
+    from utils.config_schema import validate_config
+
+    cfg = _load_template()
+
+    stage = validate_config(cfg).pipeline[0]
+
+    assert stage.behavior_cloning is None
 
 
 def test_template_resolves_to_registered_agent() -> None:

--- a/tests/test_warm_start_policy.py
+++ b/tests/test_warm_start_policy.py
@@ -1,0 +1,99 @@
+import pytest
+
+from algorithms.agents.baseline_policies import RBCCommunityPolicy, RBCSmartPolicy
+from algorithms.utils.warm_start_policy import build_warm_start_policy
+
+
+class DummySpace:
+    def __init__(self, low, high):
+        self.low = low
+        self.high = high
+
+
+def test_build_warm_start_policy_instantiates_and_attaches_rbc_community():
+    observation_names = [
+        ["hour", "pv_power_kw", "electrical_storage_soc"],
+        ["hour", "load_power_kw"],
+    ]
+    action_names = [["electrical_storage"], ["electric_vehicle_storage_charger_2_1"]]
+    action_space = [DummySpace([-1.0], [1.0]), DummySpace([0.0], [1.0])]
+    observation_space = [object(), object()]
+    metadata = {"building_names": ["Building_1", "Building_2"], "seconds_per_time_step": 900}
+
+    policy = build_warm_start_policy(
+        owner_name="TransformerPPO",
+        policy_name="RBCCommunityPolicy",
+        policy_hyperparameters=None,
+        config_template={"algorithm": {"name": "TransformerPPO"}, "simulator": {}},
+        observation_names=observation_names,
+        action_names=action_names,
+        action_space=action_space,
+        observation_space=observation_space,
+        metadata=metadata,
+    )
+
+    assert isinstance(policy, RBCCommunityPolicy)
+    assert policy._action_labels == action_names
+    assert policy._obs_index == [
+        {"hour": 0, "pv_power_kw": 1, "electrical_storage_soc": 2},
+        {"hour": 0, "load_power_kw": 1},
+    ]
+    assert policy._agent_buildings == {0: "Building_1", 1: "Building_2"}
+    assert policy.step_hours == pytest.approx(0.25)
+
+
+def test_build_warm_start_policy_passes_hyperparameters():
+    policy = build_warm_start_policy(
+        owner_name="TransformerPPO",
+        policy_name="RBCSmartPolicy",
+        policy_hyperparameters={"pv_preferred_charge_rate": 0.37},
+        config_template={"algorithm": {"name": "TransformerPPO"}},
+        observation_names=[["hour"]],
+        action_names=[["electric_vehicle_storage_charger_1_1"]],
+        action_space=[DummySpace([0.0], [1.0])],
+        observation_space=[None],
+        metadata=None,
+    )
+
+    assert isinstance(policy, RBCSmartPolicy)
+    assert policy.pv_preferred_charge_rate == pytest.approx(0.37)
+
+
+def test_build_warm_start_policy_rejects_unsupported_policy():
+    with pytest.raises(ValueError) as exc_info:
+        build_warm_start_policy(
+            owner_name="TransformerPPO",
+            policy_name="UnsupportedPolicy",
+            policy_hyperparameters=None,
+            config_template={},
+            observation_names=[[]],
+            action_names=[[]],
+            action_space=[],
+            observation_space=[],
+            metadata=None,
+        )
+
+    message = str(exc_info.value)
+    assert "TransformerPPO" in message
+    assert "UnsupportedPolicy" in message
+    assert "RBCCommunityPolicy" in message
+
+
+def test_build_warm_start_policy_rejects_non_mapping_hyperparameters():
+    with pytest.raises(ValueError) as exc_info:
+        build_warm_start_policy(
+            owner_name="TransformerPPO",
+            policy_name="RBCCommunityPolicy",
+            policy_hyperparameters=[("pv_preferred_charge_rate", 0.37)],
+            config_template={},
+            observation_names=[[]],
+            action_names=[[]],
+            action_space=[],
+            observation_space=[],
+            metadata=None,
+        )
+
+    message = str(exc_info.value)
+    assert "TransformerPPO" in message
+    assert "RBCCommunityPolicy" in message
+    assert "hyperparameters" in message

--- a/utils/config_schema.py
+++ b/utils/config_schema.py
@@ -657,6 +657,12 @@ class TransformerPPOBehaviorCloningConfig(BaseModel):
     storage_multiplier: float = Field(default=1.0, ge=0.0)
     warm_start: Optional[TransformerPPOWarmStartConfig] = None
 
+    @model_validator(mode="after")
+    def validate_enabled_has_warm_start(self) -> "TransformerPPOBehaviorCloningConfig":
+        if self.enabled and self.warm_start is None:
+            raise ValueError("TransformerPPO behavior_cloning.enabled requires warm_start.")
+        return self
+
 
 class TransformerPPOStageConfig(BaseModel):
     algorithm: Literal["AgentTransformerPPO"]

--- a/utils/config_schema.py
+++ b/utils/config_schema.py
@@ -638,6 +638,26 @@ class TransformerPPOHyperparameters(BaseModel):
     max_grad_norm: float = Field(gt=0)
 
 
+class TransformerPPOWarmStartConfig(BaseModel):
+    policy: str = Field(min_length=1)
+    deterministic: bool = True
+    noise_scale: float = Field(default=0.0, ge=0.0)
+    phaseout_steps: int = Field(default=0, ge=0)
+    phaseout_mode: Literal["probability", "blend"] = "blend"
+    hyperparameters: Dict[str, Any] = Field(default_factory=dict)
+
+
+class TransformerPPOBehaviorCloningConfig(BaseModel):
+    enabled: bool = True
+    weight: float = Field(default=0.0, ge=0.0)
+    min_weight: float = Field(default=0.0, ge=0.0)
+    decay_start_step: int = Field(default=0, ge=0)
+    decay_steps: int = Field(default=0, ge=0)
+    ev_multiplier: float = Field(default=1.0, ge=0.0)
+    storage_multiplier: float = Field(default=1.0, ge=0.0)
+    warm_start: Optional[TransformerPPOWarmStartConfig] = None
+
+
 class TransformerPPOStageConfig(BaseModel):
     algorithm: Literal["AgentTransformerPPO"]
     count: int = Field(default=1, ge=1)
@@ -645,6 +665,7 @@ class TransformerPPOStageConfig(BaseModel):
     tokenizer_config_path: str = Field(min_length=1)
     transformer: TransformerPPOTransformerConfig
     hyperparameters: TransformerPPOHyperparameters
+    behavior_cloning: Optional[TransformerPPOBehaviorCloningConfig] = None
 
 
 PipelineStageConfig = Union[


### PR DESCRIPTION
## Summary

Adds optional Behavior Cloning (BC) support to `AgentTransformerPPO` using a composition-based regularizer instead of a separate agent class.

- Adds `BehaviorCloningRegularizer` for teacher-policy actions, BC loss, per-CA weighting, warm-start phaseout, topology-safe buffers, and diagnostics.
- Adds shared `build_warm_start_policy(...)` helper and migrates existing PPO warm-start construction to use it.
- Adds optional `behavior_cloning` config schema and a BC-enabled dynamic entity template using `RBCCommunityPolicy`.
- Ensures BC-enabled TPPO requests raw observation context so the RBC teacher receives raw observations.
- Preserves dynamic-topology safety by clearing BC buffers only for changed buildings and keeping unchanged rollout/teacher buffers aligned.
- Adds smoke coverage that verifies both BC metrics and topology mutation behavior.

## Key Files

- `algorithms/utils/behavior_cloning.py`
- `algorithms/utils/warm_start_policy.py`
- `algorithms/agents/agent_transformer_ppo.py`
- `configs/templates/dynamic/transformer_ppo_bc_entity_dynamic.yaml`
- `tests/test_template_transformer_ppo_bc_entity_dynamic.py`
- `docs/transformer_ppo_spec.md`

## Smoke Evidence

`test_transformer_ppo_bc_smoke_records_bc_metrics_across_topology_change` verifies:

- BC teacher is enabled.
- Teacher actions are available.
- Warm-start phaseout is active and used.
- BC effective weight is finite and positive.
- BC loss and valid-sample diagnostics are emitted.
- Topology version increments.
- Layout/action count changes after topology mutation.
- BC buffers clear after topology mutation and realign after another rollout.

## Test Plan

- `python -m pytest tests/test_ppo_components.py tests/test_warm_start_policy.py tests/test_behavior_cloning_regularizer.py tests/test_agent_transformer_ppo.py tests/test_agent_transformer_ppo_wrapper_integration.py tests/test_agent_transformer_ppo_behavior_cloning.py tests/test_template_transformer_ppo_bc_entity_dynamic.py tests/test_template_transformer_ppo_entity_dynamic.py tests/test_rl_agents_contract.py tests/test_registry.py tests/test_pipeline.py -q`
  - Result: `163 passed, 29 warnings`

- `python -m pytest -q`
  - Result: `615 passed, 36 warnings`